### PR TITLE
feat: add `algolia-cli` skill for managing Algolia via CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,6 +17,15 @@
       "skills": [
         "./skills/algolia-mcp"
       ]
+    },
+    {
+      "name": "algolia-cli",
+      "description": "Skill for managing Algolia indices, records, settings, rules, and synonyms using the Algolia CLI.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/algolia-cli"
+      ]
     }
   ]
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,18 @@
+name: Validate Skills
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install pyyaml
+      - run: python scripts/validate_skills.py

--- a/README.md
+++ b/README.md
@@ -114,6 +114,50 @@ Interactive usage examples with copy-paste prompts.
 - **MCP client** - Claude Code (for the full skill experience), or Codex, VS Code, Cursor, etc.
 - **Node.js 18+** - Required for the `mcp-remote` bridge used by non-Claude Code clients
 
+---
+
+## Algolia CLI Skill
+
+Manage Algolia indices, records, settings, rules, and synonyms directly from the terminal using the [Algolia CLI](https://www.algolia.com/doc/tools/cli/get-started).
+
+#### Installation
+
+```bash
+/plugin install algolia-cli@algolia-skills
+```
+
+#### Getting Started
+
+Run `/algolia-cli:setup` to install the CLI and configure your credentials — or ask the agent to set up the Algolia CLI.
+
+Then try:
+
+```
+"List all my Algolia indices"
+"Export all records from the products index"
+"Copy settings from staging to production index"
+```
+
+#### Commands
+
+##### `/algolia-cli:setup`
+
+Install the Algolia CLI and configure a profile.
+
+```
+/algolia-cli:setup
+```
+
+[Full command documentation](commands/setup.md)
+
+#### Prerequisites
+
+- **Algolia account** — [Sign up free](https://www.algolia.com/users/sign_up)
+- **Application ID and Admin API key** — Found in [Dashboard → Settings → API Keys](https://dashboard.algolia.com/account/api-keys/all)
+- **Homebrew** (macOS) or package manager for installation
+
+---
+
 ### 📄 License
 
 MIT License - see [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -1,163 +1,90 @@
-# Algolia Agent Skill
+# Algolia Skills
 
-An [Agent Skill](https://agentskills.io/) that connects to Algolia for natural language search, analytics, and recommendations.
+[Agent skills](https://agentskills.io/) for managing Algolia search, analytics, recommendations, and index configuration.
 
-### ✨ Features
+## ✨ Skills
 
-- 🔍 **Natural Language Search** - Search your Algolia indices conversationally
-- 📊 **Analytics Insights** - Get search analytics through simple questions
-- 🎯 **Smart Recommendations** - Product recommendations (bought-together, related, trending, similar)
-- 🚀 **Easy Setup** - Connect in minutes with `/algolia-mcp:connect` in Claude Code
-- 📚 **Usage Examples** - Run `/algolia-mcp:examples` for copy-paste prompts
+Pick the skill that fits your workflow.
 
-### 🛠️ Usage
+| Skill                       | Description                                                       |
+|-----------------------------|-------------------------------------------------------------------|
+| [algolia-mcp](#algolia-mcp) | Search, analytics, and recommendations via the Algolia MCP server |
+| [algolia-cli](#algolia-cli) | Manage indices, settings, rules, and synonyms via the Algolia CLI |
 
-The skill gives you `/algolia-mcp:connect` and `/algolia-mcp:examples` slash commands, plus guided setup and interactive examples.
+### algolia-mcp
 
-#### Installation
+Search your Algolia indices with natural language, explore search analytics, and get product recommendations (bought-together, related, trending, similar) — all through the Algolia MCP server.
 
-##### Option 1: From Marketplace (Recommended)
+#### Commands
 
-**Two steps:**
+| Command                 | Description                                        | Docs                                |
+|-------------------------|----------------------------------------------------|-------------------------------------|
+| `/algolia-mcp:connect`  | Set up or update your Algolia MCP connection       | [connect.md](commands/connect.md)   |
+| `/algolia-mcp:examples` | Interactive usage examples with copy-paste prompts | [examples.md](commands/examples.md) |
 
-1. Add the Algolia marketplace:
-   ```bash
-   /plugin marketplace add algolia/skills
-   ```
+`/algolia-mcp:examples` accepts an optional category: `search`, `analytics`, or `recommendations`.
 
-2. Install the plugin:
-   ```bash
-   /plugin install algolia-mcp
-   ```
+#### Prerequisites
 
-**Or direct install (one step):**
+- [Algolia account](https://www.algolia.com/users/sign_up) with at least one index containing data
+- Algolia MCP enabled in Dashboard (Generate AI > MCP Servers > Productivity)
+- MCP client — Claude Code, Codex, VS Code, Cursor, etc.
+- Node.js 18+ (required for `mcp-remote` bridge on non-Claude Code clients)
+
+### algolia-cli
+
+Manage Algolia indices, records, settings, rules, and synonyms from the terminal using the [Algolia CLI](https://www.algolia.com/doc/tools/cli/get-started).
+
+#### Commands
+
+| Command              | Description                                     | Docs                          |
+|----------------------|-------------------------------------------------|-------------------------------|
+| `/algolia-cli:setup` | Install the Algolia CLI and configure a profile | [setup.md](commands/setup.md) |
+
+#### Prerequisites
+
+- [Algolia account](https://www.algolia.com/users/sign_up) with Application ID and Admin API key ([Dashboard > Settings > API Keys](https://dashboard.algolia.com/account/api-keys/all))
+- Homebrew (macOS) or a compatible package manager
+
+## 🛠️ Installation
+
+### From Marketplace (recommended)
 
 ```bash
-/plugin install algolia-mcp@algolia-skills
+/plugin marketplace add algolia/skills
+/plugin install algolia-mcp   # or algolia-cli
 ```
 
-##### Option 2: Via npx
+Or install directly:
+
+```bash
+/plugin install algolia-mcp@algolia-skills   # or algolia-cli@algolia-skills
+```
+
+### Via npx
 
 ```bash
 npx skills add https://github.com/algolia/skills
 ```
 
-##### Option 3: Manual
+### Clone / Copy
 
-1. Clone this repository:
-   ```bash
-   git clone https://github.com/algolia/skills.git
-   cd skills
-   ```
-
-2. Copy the skill to your Claude skills directory:
-   ```bash
-   mkdir -p ~/.claude/skills
-   cp -r skills/algolia-mcp ~/.claude/skills/
-   ```
-
-3. Restart Claude Code to load the skill.
-
-#### Verify Installation
-
-```
-What skills are available?
-```
-
-You should see `algolia-mcp` in the list.
-
-#### Getting Started
-
-Once installed, set up your Algolia MCP connection:
-
-- **If your client supports commands**, run `/algolia-mcp:connect` — it will guide you through the entire setup.
-- **Otherwise**, ask the agent to set up Algolia MCP (e.g. *"Set up Algolia MCP"*) and it will follow the skill's instructions.
-
-Then try:
-
-```
-"Search my products index for laptop under $1000"
-"What were the top searches yesterday?"
-"Show me trending products in electronics"
-```
-
-#### Commands
-
-##### `/algolia-mcp:connect`
-
-Set up or update your Algolia MCP connection.
-
-```
-/algolia-mcp:connect
-```
-
-[Full command documentation](commands/connect.md)
-
-##### `/algolia-mcp:examples`
-
-Interactive usage examples with copy-paste prompts.
-
-```
-/algolia-mcp:examples                  # All examples
-/algolia-mcp:examples search           # Search patterns
-/algolia-mcp:examples analytics        # Analytics patterns
-/algolia-mcp:examples recommendations  # Recommendations patterns
-```
-
-[Full command documentation](commands/examples.md)
-
-### 📋 Prerequisites
-
-- **Algolia account** - [Sign up free](https://www.algolia.com/users/sign_up)
-- **At least one index** with data in your Algolia application
-- **Algolia MCP enabled** in Dashboard (Generate AI → MCP Servers → Productivity)
-- **MCP client** - Claude Code (for the full skill experience), or Codex, VS Code, Cursor, etc.
-- **Node.js 18+** - Required for the `mcp-remote` bridge used by non-Claude Code clients
-
----
-
-## Algolia CLI Skill
-
-Manage Algolia indices, records, settings, rules, and synonyms directly from the terminal using the [Algolia CLI](https://www.algolia.com/doc/tools/cli/get-started).
-
-#### Installation
+Clone the repo and copy the skill folder to your agent's skills directory:
 
 ```bash
-/plugin install algolia-cli@algolia-skills
+git clone https://github.com/algolia/skills.git
+cp -r skills/algolia-mcp <skills-directory>   # or algolia-cli
 ```
 
-#### Getting Started
+| Agent        | Skills directory             |
+|--------------|------------------------------|
+| Claude Code  | `~/.claude/skills/`          |
+| Cursor       | `~/.cursor/skills/`          |
+| OpenAI Codex | `~/.codex/skills/`           |
+| OpenCode     | `~/.config/opencode/skills/` |
 
-Run `/algolia-cli:setup` to install the CLI and configure your credentials — or ask the agent to set up the Algolia CLI.
+Restart your agent to load the skill.
 
-Then try:
+## 📄 License
 
-```
-"List all my Algolia indices"
-"Export all records from the products index"
-"Copy settings from staging to production index"
-```
-
-#### Commands
-
-##### `/algolia-cli:setup`
-
-Install the Algolia CLI and configure a profile.
-
-```
-/algolia-cli:setup
-```
-
-[Full command documentation](commands/setup.md)
-
-#### Prerequisites
-
-- **Algolia account** — [Sign up free](https://www.algolia.com/users/sign_up)
-- **Application ID and Admin API key** — Found in [Dashboard → Settings → API Keys](https://dashboard.algolia.com/account/api-keys/all)
-- **Homebrew** (macOS) or package manager for installation
-
----
-
-### 📄 License
-
-MIT License - see [LICENSE](LICENSE) file for details.
+MIT — see [LICENSE](LICENSE) for details.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,0 +1,84 @@
+---
+name: setup
+description: Install the Algolia CLI and configure a profile with credentials.
+skill: algolia-cli
+---
+
+# Algolia CLI Setup
+
+Guide the user through installing the Algolia CLI and configuring their credentials.
+
+## Step 1: Check if the CLI is installed
+
+Run:
+
+```bash
+algolia --version
+```
+
+- **If the command succeeds**, skip to Step 3.
+- **If the command fails** (command not found), proceed to Step 2.
+
+## Step 2: Install the CLI
+
+Detect the platform and install:
+
+**macOS (Homebrew):**
+
+```bash
+brew install algolia/algolia-cli/algolia
+```
+
+**Linux (Debian/Ubuntu):**
+
+```bash
+echo "deb [trusted=yes] https://algolia.github.io/cli/deb/ /" | sudo tee /etc/apt/sources.list.d/algolia-cli.list
+sudo apt update && sudo apt install algolia
+```
+
+**Other platforms:** Direct the user to https://www.algolia.com/doc/tools/cli/get-started for download options.
+
+After installation, verify:
+
+```bash
+algolia --version
+```
+
+## Step 3: Check for existing profiles
+
+Run:
+
+```bash
+algolia profile list
+```
+
+- **If profiles exist**, ask the user if they want to use an existing profile or create a new one.
+- **If no profiles exist** (or the command shows an empty list), proceed to Step 4.
+
+## Step 4: Create a profile
+
+Ask the user for:
+1. **Application ID** — Found in Algolia Dashboard → Settings → API Keys
+2. **Admin API key** — Same location. Needed for write operations.
+
+Then run:
+
+```bash
+algolia profile add --name "default" --app-id "<APP_ID>" --api-key "<API_KEY>" --default
+```
+
+> **Important:** Always provide all three flags to avoid interactive prompts.
+
+## Step 5: Verify the connection
+
+Run:
+
+```bash
+algolia indices list
+```
+
+- **If indices are listed**, setup is complete. Tell the user they're ready to go.
+- **If an error occurs**, check:
+  - Invalid API key → ask user to double-check credentials
+  - Network error → ask user to check connectivity
+  - No indices → that's fine, the connection works but the app has no indices yet

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Validate Agent Skills against the agentskills.io specification.
+
+Checks:
+  - SKILL.md exists in each skill directory
+  - Valid YAML frontmatter
+  - Required fields: name, description
+  - name: 1-64 chars, lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, matches directory name
+  - description: 1-1024 chars
+  - compatibility (if present): 1-500 chars
+  - Body: under 500 lines
+  - Relative markdown links resolve to existing files
+  - marketplace.json: valid JSON, referenced skill paths exist
+
+Reference: https://agentskills.io/specification
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML is required: pip install pyyaml")
+    sys.exit(1)
+
+# --- Spec limits ---
+NAME_MAX_LEN = 64
+DESC_MAX_LEN = 1024
+COMPAT_MAX_LEN = 500
+BODY_MAX_LINES = 500
+NAME_RE = re.compile(r"^[a-z0-9](-?[a-z0-9])*$")
+LINK_RE = re.compile(r"\[.*?]\(((?!https?://|#|mailto:).*?)\)")
+
+errors: list[str] = []
+
+
+def error(context: str, msg: str) -> None:
+    errors.append(f"{context}: {msg}")
+
+
+def validate_string_field(ctx: str, fm: dict, field: str, max_len: int, *, required: bool = True) -> str | None:
+    value = fm.get(field)
+    if value is None:
+        if required:
+            error(ctx, f"missing required field '{field}'")
+        return None
+    if not isinstance(value, str) or not value:
+        error(ctx, f"'{field}' must be a non-empty string")
+        return None
+    if len(value) > max_len:
+        error(ctx, f"'{field}' exceeds {max_len} chars ({len(value)})")
+    return value
+
+
+def validate_body_length(skill_dir: Path, body: str) -> None:
+    stripped = body.strip()
+    lines = stripped.splitlines() if stripped else []
+    if len(lines) > BODY_MAX_LINES:
+        error(
+            skill_dir.name,
+            f"SKILL.md body exceeds {BODY_MAX_LINES} lines ({len(lines)})",
+        )
+
+
+def validate_links(skill_dir: Path, body: str) -> None:
+    for match in LINK_RE.finditer(body):
+        rel_path = match.group(1).split("#")[0].strip()
+        if not rel_path:
+            continue
+        target = skill_dir / rel_path
+        if not target.exists():
+            error(skill_dir.name, f"broken link: {rel_path}")
+
+
+def validate_skill(skill_dir: Path) -> None:
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        error(skill_dir.name, "missing SKILL.md")
+        return
+
+    content = skill_md.read_text(encoding="utf-8")
+
+    # Parse frontmatter
+    if not content.startswith("---"):
+        error(skill_dir.name, "SKILL.md must start with YAML frontmatter (---)")
+        return
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        error(skill_dir.name, "SKILL.md has malformed frontmatter (missing closing ---)")
+        return
+
+    try:
+        fm = yaml.safe_load(parts[1])
+    except yaml.YAMLError as e:
+        error(skill_dir.name, f"invalid YAML frontmatter: {e}")
+        return
+
+    if not isinstance(fm, dict):
+        error(skill_dir.name, "frontmatter must be a YAML mapping")
+        return
+
+    ctx = skill_dir.name
+    name = validate_string_field(ctx, fm, "name", NAME_MAX_LEN)
+    if name is not None:
+        if not NAME_RE.match(name):
+            error(ctx, f"'name' ({name!r}) invalid: must be lowercase alphanumeric + single hyphens, no leading/trailing hyphens")
+        if name != skill_dir.name:
+            error(ctx, f"'name' ({name!r}) must match directory name ({skill_dir.name!r})")
+
+    validate_string_field(ctx, fm, "description", DESC_MAX_LEN)
+    validate_string_field(ctx, fm, "compatibility", COMPAT_MAX_LEN, required=False)
+
+    body = parts[2]
+    validate_body_length(skill_dir, body)
+    validate_links(skill_dir, body)
+
+
+def validate_marketplace(root: Path) -> None:
+    mp = root / ".claude-plugin" / "marketplace.json"
+    if not mp.exists():
+        return
+
+    try:
+        data = json.loads(mp.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        error("marketplace.json", f"invalid JSON: {e}")
+        return
+
+    for plugin in data.get("plugins", []):
+        for skill_path in plugin.get("skills", []):
+            resolved = (root / skill_path).resolve()
+            if not resolved.exists():
+                error("marketplace.json", f"skill path does not exist: {skill_path}")
+            elif not (resolved / "SKILL.md").exists():
+                error("marketplace.json", f"skill path missing SKILL.md: {skill_path}")
+
+
+def main() -> None:
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    skills_dir = root / "skills"
+
+    if not skills_dir.exists():
+        print(f"Skills directory not found: {skills_dir}")
+        sys.exit(1)
+
+    skill_dirs = sorted(d for d in skills_dir.iterdir() if d.is_dir())
+    if not skill_dirs:
+        print("No skill directories found")
+        sys.exit(1)
+
+    for skill_dir in skill_dirs:
+        validate_skill(skill_dir)
+
+    validate_marketplace(root)
+
+    if errors:
+        print(f"\n{len(errors)} error(s) found:\n")
+        for e in errors:
+            print(f"  ✗ {e}")
+        sys.exit(1)
+    else:
+        print(f"✓ All {len(skill_dirs)} skill(s) passed validation")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -34,84 +34,141 @@ BODY_MAX_LINES = 500
 NAME_RE = re.compile(r"^[a-z0-9](-?[a-z0-9])*$")
 LINK_RE = re.compile(r"\[.*?]\(((?!https?://|#|mailto:).*?)\)")
 
-errors: list[str] = []
+
+class Report:
+    def __init__(self) -> None:
+        self._results: list[tuple[str, bool, str]] = []
+
+    def pass_(self, ctx: str, msg: str) -> None:
+        self._results.append((ctx, True, msg))
+
+    def fail_(self, ctx: str, msg: str) -> None:
+        self._results.append((ctx, False, msg))
+
+    @property
+    def has_failures(self) -> bool:
+        return any(not ok for _, ok, _ in self._results)
+
+    def print_summary(self) -> None:
+        # Group by context, preserving insertion order
+        contexts: dict[str, list[tuple[bool, str]]] = {}
+        for ctx, ok, msg in self._results:
+            contexts.setdefault(ctx, []).append((ok, msg))
+
+        passed = sum(1 for _, ok, _ in self._results if ok)
+        failed = sum(1 for _, ok, _ in self._results if not ok)
+
+        for ctx, checks in contexts.items():
+            print(ctx)
+            for ok, msg in checks:
+                mark = "✓" if ok else "✗"
+                print(f"  {mark} {msg}")
+            print()
+
+        print(f"Results: {passed} passed, {failed} failed")
 
 
-def error(context: str, msg: str) -> None:
-    errors.append(f"{context}: {msg}")
+report = Report()
 
 
 def validate_string_field(ctx: str, fm: dict, field: str, max_len: int, *, required: bool = True) -> str | None:
     value = fm.get(field)
     if value is None:
         if required:
-            error(ctx, f"missing required field '{field}'")
+            report.fail_(ctx, f"required field '{field}': missing")
         return None
     if not isinstance(value, str) or not value:
-        error(ctx, f"'{field}' must be a non-empty string")
+        report.fail_(ctx, f"'{field}' must be a non-empty string")
         return None
     if len(value) > max_len:
-        error(ctx, f"'{field}' exceeds {max_len} chars ({len(value)})")
+        report.fail_(ctx, f"'{field}' exceeds {max_len} chars ({len(value)})")
+        return value
     return value
 
 
 def validate_body_length(skill_dir: Path, body: str) -> None:
+    ctx = skill_dir.name
     stripped = body.strip()
     lines = stripped.splitlines() if stripped else []
     if len(lines) > BODY_MAX_LINES:
-        error(
-            skill_dir.name,
-            f"SKILL.md body exceeds {BODY_MAX_LINES} lines ({len(lines)})",
-        )
+        report.fail_(ctx, f"body length: exceeds {BODY_MAX_LINES} lines ({len(lines)})")
+    else:
+        report.pass_(ctx, f"body length ({len(lines)} lines)")
 
 
 def validate_links(skill_dir: Path, body: str) -> None:
+    ctx = skill_dir.name
+    broken = []
     for match in LINK_RE.finditer(body):
         rel_path = match.group(1).split("#")[0].strip()
         if not rel_path:
             continue
         target = skill_dir / rel_path
         if not target.exists():
-            error(skill_dir.name, f"broken link: {rel_path}")
+            broken.append(rel_path)
+
+    if broken:
+        for link in broken:
+            report.fail_(ctx, f"relative links: broken link {link}")
+    else:
+        report.pass_(ctx, "relative links")
 
 
 def validate_skill(skill_dir: Path) -> None:
+    ctx = skill_dir.name
     skill_md = skill_dir / "SKILL.md"
     if not skill_md.exists():
-        error(skill_dir.name, "missing SKILL.md")
+        report.fail_(ctx, "SKILL.md exists: missing")
         return
+
+    report.pass_(ctx, "SKILL.md exists")
 
     content = skill_md.read_text(encoding="utf-8")
 
     # Parse frontmatter
     if not content.startswith("---"):
-        error(skill_dir.name, "SKILL.md must start with YAML frontmatter (---)")
+        report.fail_(ctx, "valid YAML frontmatter: must start with ---")
         return
 
     parts = content.split("---", 2)
     if len(parts) < 3:
-        error(skill_dir.name, "SKILL.md has malformed frontmatter (missing closing ---)")
+        report.fail_(ctx, "valid YAML frontmatter: missing closing ---")
         return
 
     try:
         fm = yaml.safe_load(parts[1])
     except yaml.YAMLError as e:
-        error(skill_dir.name, f"invalid YAML frontmatter: {e}")
+        report.fail_(ctx, f"valid YAML frontmatter: {e}")
         return
 
     if not isinstance(fm, dict):
-        error(skill_dir.name, "frontmatter must be a YAML mapping")
+        report.fail_(ctx, "valid YAML frontmatter: must be a YAML mapping")
         return
 
-    ctx = skill_dir.name
-    name = validate_string_field(ctx, fm, "name", NAME_MAX_LEN)
-    if name is not None:
-        if not NAME_RE.match(name):
-            error(ctx, f"'name' ({name!r}) invalid: must be lowercase alphanumeric + single hyphens, no leading/trailing hyphens")
-        if name != skill_dir.name:
-            error(ctx, f"'name' ({name!r}) must match directory name ({skill_dir.name!r})")
+    report.pass_(ctx, "valid YAML frontmatter")
 
-    validate_string_field(ctx, fm, "description", DESC_MAX_LEN)
+    # Required fields
+    name = validate_string_field(ctx, fm, "name", NAME_MAX_LEN)
+    desc = validate_string_field(ctx, fm, "description", DESC_MAX_LEN)
+    if name is not None and desc is not None:
+        report.pass_(ctx, "required fields (name, description)")
+    elif name is None and desc is None:
+        pass  # individual failures already recorded
+    else:
+        pass  # individual failure already recorded
+
+    # Name format & directory match
+    if name is not None:
+        name_ok = True
+        if not NAME_RE.match(name):
+            report.fail_(ctx, f"name format: {name!r} invalid — must be lowercase alphanumeric + single hyphens")
+            name_ok = False
+        if name != skill_dir.name:
+            report.fail_(ctx, f"name format: {name!r} must match directory name {skill_dir.name!r}")
+            name_ok = False
+        if name_ok:
+            report.pass_(ctx, "name format and directory match")
+
     validate_string_field(ctx, fm, "compatibility", COMPAT_MAX_LEN, required=False)
 
     body = parts[2]
@@ -120,6 +177,7 @@ def validate_skill(skill_dir: Path) -> None:
 
 
 def validate_marketplace(root: Path) -> None:
+    ctx = "marketplace.json"
     mp = root / ".claude-plugin" / "marketplace.json"
     if not mp.exists():
         return
@@ -127,16 +185,24 @@ def validate_marketplace(root: Path) -> None:
     try:
         data = json.loads(mp.read_text(encoding="utf-8"))
     except json.JSONDecodeError as e:
-        error("marketplace.json", f"invalid JSON: {e}")
+        report.fail_(ctx, f"valid JSON: {e}")
         return
 
+    report.pass_(ctx, "valid JSON")
+
+    all_exist = True
     for plugin in data.get("plugins", []):
         for skill_path in plugin.get("skills", []):
             resolved = (root / skill_path).resolve()
             if not resolved.exists():
-                error("marketplace.json", f"skill path does not exist: {skill_path}")
+                report.fail_(ctx, f"skill paths exist: {skill_path} not found")
+                all_exist = False
             elif not (resolved / "SKILL.md").exists():
-                error("marketplace.json", f"skill path missing SKILL.md: {skill_path}")
+                report.fail_(ctx, f"skill paths exist: {skill_path} missing SKILL.md")
+                all_exist = False
+
+    if all_exist:
+        report.pass_(ctx, "skill paths exist")
 
 
 def main() -> None:
@@ -157,13 +223,9 @@ def main() -> None:
 
     validate_marketplace(root)
 
-    if errors:
-        print(f"\n{len(errors)} error(s) found:\n")
-        for e in errors:
-            print(f"  ✗ {e}")
+    report.print_summary()
+    if report.has_failures:
         sys.exit(1)
-    else:
-        print(f"✓ All {len(skill_dirs)} skill(s) passed validation")
 
 
 if __name__ == "__main__":

--- a/skills/algolia-cli/SKILL.md
+++ b/skills/algolia-cli/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: algolia-cli
+description: Manage Algolia indices, records, settings, rules, and synonyms using the Algolia CLI. Triggers on CLI, command-line, algolia, indices, objects, settings, rules, synonyms, import, export.
+license: MIT
+metadata:
+  author: algolia
+  version: "1.0"
+---
+
+# Algolia CLI
+
+Manage Algolia search infrastructure from the terminal using the `algolia` CLI.
+
+## Setup
+
+Run `/algolia-cli:setup` to install the CLI and configure a profile, or follow [Getting Started](references/getting-started.md).
+
+## Command Quick Reference
+
+### Profile
+
+| Task                          | Command                                                                            |
+|-------------------------------|------------------------------------------------------------------------------------|
+| Add profile (non-interactive) | `algolia profile add --name "default" --app-id "<ID>" --api-key "<KEY>" --default` |
+| List profiles                 | `algolia profile list`                                                             |
+
+### Search
+
+| Task                | Command                                                              |
+|---------------------|----------------------------------------------------------------------|
+| Search an index     | `algolia search <index> --query "<query>"`                           |
+| Search with filters | `algolia search <index> --query "<query>" --filters "<filter>"`      |
+| Paginated search    | `algolia search <index> --query "<query>" --hitsPerPage 10 --page 2` |
+
+### Indices
+
+| Task                          | Command                                                |
+|-------------------------------|--------------------------------------------------------|
+| List all indices              | `algolia indices list`                                 |
+| Delete an index               | `algolia indices delete <index> -y`                    |
+| Clear records (keep settings) | `algolia indices clear <index> -y`                     |
+| Copy index                    | `algolia indices copy <src> <dst> -y`                  |
+| Copy only settings            | `algolia indices copy <src> <dst> --scope settings -y` |
+| Move/rename index             | `algolia indices move <src> <dst> -y`                  |
+
+### Objects (Records)
+
+| Task                       | Command                                                             |
+|----------------------------|---------------------------------------------------------------------|
+| Browse all records         | `algolia objects browse <index>`                                    |
+| Browse specific attributes | `algolia objects browse <index> --attributesToRetrieve title,price` |
+| Import records from file   | `algolia objects import <index> -F data.ndjson`                     |
+| Import from stdin          | `cat data.ndjson \| algolia objects import <index> -F -`            |
+| Delete by IDs              | `algolia objects delete <index> --object-ids id1,id2 -y`            |
+| Delete by filter           | `algolia objects delete <index> --filters "type:obsolete" -y`       |
+| Partial update             | `algolia objects update <index> -F updates.ndjson`                  |
+
+### Settings
+
+| Task                           | Command                                                |
+|--------------------------------|--------------------------------------------------------|
+| Get settings                   | `algolia settings get <index>`                         |
+| Set a setting                  | `algolia settings set <index> --typoTolerance="false"` |
+| Import settings from file      | `algolia settings import <index> -F settings.json`     |
+| Import and forward to replicas | `algolia settings import <index> -F settings.json -f`  |
+
+### Rules
+
+| Task               | Command                                              |
+|--------------------|------------------------------------------------------|
+| Browse all rules   | `algolia rules browse <index>`                       |
+| Import rules       | `algolia rules import <index> -F rules.ndjson -y`    |
+| Replace all rules  | `algolia rules import <index> -F rules.ndjson -c -y` |
+| Delete rules by ID | `algolia rules delete <index> --rule-ids id1,id2 -y` |
+
+### Synonyms
+
+| Task                  | Command                                                        |
+|-----------------------|----------------------------------------------------------------|
+| Browse all synonyms   | `algolia synonyms browse <index>`                              |
+| Import synonyms       | `algolia synonyms import <index> -F synonyms.ndjson`           |
+| Replace all synonyms  | `algolia synonyms import <index> -F synonyms.ndjson -r`        |
+| Delete synonyms by ID | `algolia synonyms delete <index> --synonym-ids id1,id2 -y`     |
+| Save a single synonym | `algolia synonyms save <index> --id my-syn --synonyms foo,bar` |
+
+## Key Conventions
+
+1. **Always use non-interactive mode.** Pass all required flags explicitly so the CLI never prompts for input. Use `-y` (or `--confirm`) to skip confirmation prompts.
+2. **ndjson format.** `objects browse`, `objects import`, `rules browse/import`, and `synonyms browse/import` use newline-delimited JSON (one JSON object per line), **not** JSON arrays.
+3. **Profile flag.** Use `-p <profile>` to target a non-default profile. Omit it to use the default.
+4. **Wait flag.** Use `-w` (or `--wait`) when subsequent commands depend on the operation completing (e.g., import then search).
+5. **Pipe between commands.** Copy data across indices: `algolia objects browse SRC | algolia objects import DST -F -`
+6. **JSON output.** Use `--output json` (or `-o json`) when you need machine-readable output.
+
+## Reference Docs
+
+- [Getting Started](references/getting-started.md) — Installation and profile setup
+- [Command Reference](references/commands.md) — Full syntax, flags, and examples for every command

--- a/skills/algolia-cli/SKILL.md
+++ b/skills/algolia-cli/SKILL.md
@@ -88,9 +88,10 @@ Run `/algolia-cli:setup` to install the CLI and configure a profile, or follow [
 1. **Always use non-interactive mode.** Pass all required flags explicitly so the CLI never prompts for input. Use `-y` (or `--confirm`) to skip confirmation prompts.
 2. **ndjson format.** `objects browse`, `objects import`, `rules browse/import`, and `synonyms browse/import` use newline-delimited JSON (one JSON object per line), **not** JSON arrays.
 3. **Profile flag.** Use `-p <profile>` to target a non-default profile. Omit it to use the default.
-4. **Wait flag.** Use `-w` (or `--wait`) when subsequent commands depend on the operation completing (e.g., import then search).
-5. **Pipe between commands.** Copy data across indices: `algolia objects browse SRC | algolia objects import DST -F -`
-6. **JSON output.** Use `--output json` (or `-o json`) when you need machine-readable output.
+4. **Credential precedence.** Environment variables override all other configuration. The resolution order is: **env vars** > **CLI flags** (`--application-id`, `--api-key`) > **profile config file** > **default profile**. Supported env vars: `ALGOLIA_APPLICATION_ID`, `ALGOLIA_API_KEY`, `ALGOLIA_ADMIN_API_KEY`, `ALGOLIA_SEARCH_HOSTS`, `ALGOLIA_CRAWLER_USER_ID`, `ALGOLIA_CRAWLER_API_KEY`. If env vars are set, `--profile`/`-p` is ignored for those credentials.
+5. **Wait flag.** Use `-w` (or `--wait`) when subsequent commands depend on the operation completing (e.g., import then search).
+6. **Pipe between commands.** Copy data across indices: `algolia objects browse SRC | algolia objects import DST -F -`
+7. **JSON output.** Use `--output json` (or `-o json`) when you need machine-readable output.
 
 ## Reference Docs
 

--- a/skills/algolia-cli/SKILL.md
+++ b/skills/algolia-cli/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: algolia-cli
-description: Manage Algolia indices, records, settings, rules, and synonyms using the Algolia CLI. Triggers on CLI, command-line, algolia, indices, objects, settings, rules, synonyms, import, export.
+description: >-
+  Use when managing Algolia search infrastructure from the command line —
+  creating or configuring profiles, searching indices, importing or exporting
+  records, managing index settings, rules, synonyms, and API keys. Applies
+  even when the user says "search index," "import data," or "update settings"
+  without explicitly mentioning the Algolia CLI.
 license: MIT
 metadata:
   author: algolia
@@ -23,6 +28,17 @@ Run `/algolia-cli:setup` to install the CLI and configure a profile, or follow [
 |-------------------------------|------------------------------------------------------------------------------------|
 | Add profile (non-interactive) | `algolia profile add --name "default" --app-id "<ID>" --api-key "<KEY>" --default` |
 | List profiles                 | `algolia profile list`                                                             |
+| Remove a profile              | `algolia profile remove "<name>" -y`                                               |
+| Set default profile           | `algolia profile setdefault "<name>"`                                              |
+
+### API Keys
+
+| Task             | Command                                                                              |
+|------------------|--------------------------------------------------------------------------------------|
+| List API keys    | `algolia apikeys list`                                                               |
+| Create API key   | `algolia apikeys create --acl search,browse --description "..." --indices "idx1,idx2"` |
+| Get API key      | `algolia apikeys get <key>`                                                          |
+| Delete API key   | `algolia apikeys delete <key> -y`                                                    |
 
 ### Search
 

--- a/skills/algolia-cli/references/commands.md
+++ b/skills/algolia-cli/references/commands.md
@@ -1,0 +1,659 @@
+# Algolia CLI Command Reference
+
+Complete reference for agent-useful commands. All examples use non-interactive flags to avoid TTY prompts.
+
+---
+
+## Profile Management
+
+### `algolia profile add`
+
+Create a new CLI profile with Algolia credentials.
+
+```bash
+algolia profile add --name "<name>" --app-id "<app-id>" --api-key "<api-key>" [--default]
+```
+
+| Flag        | Short | Required | Description            |
+|-------------|-------|----------|------------------------|
+| `--name`    | `-n`  | Yes*     | Profile name           |
+| `--app-id`  |       | Yes*     | Algolia Application ID |
+| `--api-key` |       | Yes*     | Algolia API key        |
+| `--default` | `-d`  | No       | Set as default profile |
+
+*All three must be provided to skip interactive mode.
+
+```bash
+# Add default profile
+algolia profile add --name "default" --app-id "ABC123" --api-key "xyz789" --default
+
+# Add secondary profile
+algolia profile add --name "staging" --app-id "STG456" --api-key "stg000"
+```
+
+### `algolia profile list`
+
+List all configured profiles.
+
+```bash
+algolia profile list
+```
+
+Output columns: NAME, APPLICATION ID, NUMBER OF INDICES, DEFAULT.
+
+---
+
+## Search
+
+### `algolia search`
+
+Run a search query against an index.
+
+```bash
+algolia search <index> [flags]
+```
+
+| Flag            | Short | Default | Description             |
+|-----------------|-------|---------|-------------------------|
+| `--query`       |       | `""`    | Search query string     |
+| `--filters`     |       |         | Filter expression       |
+| `--hitsPerPage` |       | `20`    | Results per page        |
+| `--page`        |       | `0`     | Page number (0-indexed) |
+| `--output`      | `-o`  | `json`  | Output format           |
+
+```bash
+# Basic search
+algolia search MOVIES --query "toy story"
+
+# With filters
+algolia search MOVIES --query "toy story" --filters "(genres:Animation OR genres:Family) AND original_language:en"
+
+# Paginated
+algolia search MOVIES --query "toy story" --hitsPerPage 5 --page 2
+
+# Save results to file
+algolia search MOVIES --query "toy story" > results.json
+
+# Extract only hits
+algolia search MOVIES --query "toy story" --output="jsonpath={$.Hits}" > hits.json
+```
+
+**Required ACL:** `search`
+
+---
+
+## Indices
+
+### `algolia indices list`
+
+List all indices in the application.
+
+```bash
+algolia indices list
+```
+
+Output columns: NAME, ENTRIES, SIZE, UPDATED AT, CREATED AT, LAST BUILD DURATION, PRIMARY, REPLICAS.
+
+**Required ACL:** `listIndexes`
+
+### `algolia indices delete`
+
+Delete one or more indices.
+
+```bash
+algolia indices delete <index> [<index2> ...] [-y] [-r] [-w]
+```
+
+| Flag                 | Short | Default | Description                 |
+|----------------------|-------|---------|-----------------------------|
+| `--confirm`          | `-y`  | `false` | Skip confirmation prompt    |
+| `--include-replicas` | `-r`  | `false` | Also delete replica indices |
+| `--wait`             | `-w`  | `false` | Wait for completion         |
+
+```bash
+# Delete single index
+algolia indices delete MOVIES -y
+
+# Delete index and its replicas
+algolia indices delete MOVIES -y -r
+
+# Delete multiple indices
+algolia indices delete MOVIES SERIES ANIMES -y
+```
+
+**Required ACL:** `deleteIndex`
+
+### `algolia indices clear`
+
+Remove all records from an index. Settings, synonyms, and rules are preserved.
+
+```bash
+algolia indices clear <index> [-y] [-w]
+```
+
+| Flag        | Short | Default | Description              |
+|-------------|-------|---------|--------------------------|
+| `--confirm` | `-y`  | `false` | Skip confirmation prompt |
+| `--wait`    | `-w`  | `false` | Wait for completion      |
+
+```bash
+algolia indices clear MOVIES -y
+```
+
+**Required ACL:** `deleteIndex`
+
+### `algolia indices copy`
+
+Copy an index to another. Destination index is overwritten.
+
+```bash
+algolia indices copy <source> <destination> [-s <scope>] [-y] [-w]
+```
+
+| Flag        | Short | Default | Description                                      |
+|-------------|-------|---------|--------------------------------------------------|
+| `--scope`   | `-s`  | all     | Comma-separated: `settings`, `synonyms`, `rules` |
+| `--confirm` | `-y`  | `false` | Skip confirmation prompt                         |
+| `--wait`    | `-w`  | `false` | Wait for completion                              |
+
+```bash
+# Copy everything (records + settings + synonyms + rules)
+algolia indices copy SERIES MOVIES -y
+
+# Copy only settings
+algolia indices copy SERIES MOVIES --scope settings -y
+
+# Copy synonyms and rules
+algolia indices copy SERIES MOVIES --scope synonyms,rules -y
+```
+
+**Required ACL:** `settings`, `editSettings`, `browse`, `addObject`
+
+### `algolia indices move`
+
+Move (rename) an index. The source index is deleted after the move.
+
+```bash
+algolia indices move <source> <destination> [-y] [-w]
+```
+
+| Flag        | Short | Default | Description              |
+|-------------|-------|---------|--------------------------|
+| `--confirm` | `-y`  | `false` | Skip confirmation prompt |
+| `--wait`    | `-w`  | `false` | Wait for completion      |
+
+```bash
+algolia indices move TEST_MOVIES MOVIES -y
+```
+
+**Required ACL:** `addObject`
+
+---
+
+## Objects (Records)
+
+### `algolia objects browse`
+
+Export all records from an index. Output is **ndjson** (one JSON object per line).
+
+```bash
+algolia objects browse <index> [flags]
+```
+
+| Flag                     | Short | Default | Description                     |
+|--------------------------|-------|---------|---------------------------------|
+| `--attributesToRetrieve` |       | all     | Comma-separated attribute names |
+| `--filters`              |       |         | Filter expression               |
+| `--query`                |       |         | Search query                    |
+| `--output`               | `-o`  | `json`  | Output format                   |
+
+```bash
+# Browse all records
+algolia objects browse MOVIES
+
+# Specific attributes only
+algolia objects browse MOVIES --attributesToRetrieve title,overview,genres
+
+# With filter
+algolia objects browse MOVIES --filters "genres:Drama"
+
+# Export to file
+algolia objects browse MOVIES > movies.ndjson
+```
+
+**Output format:** ndjson — one JSON object per line, not a JSON array.
+
+**Required ACL:** `browse`
+
+### `algolia objects import`
+
+Import records into an index from an **ndjson** file.
+
+```bash
+algolia objects import <index> -F <file> [flags]
+```
+
+| Flag                                     | Short | Default | Description                              |
+|------------------------------------------|-------|---------|------------------------------------------|
+| `--file`                                 | `-F`  |         | File path (`-` for stdin) — **required** |
+| `--batch-size`                           | `-b`  | `1000`  | Records per batch                        |
+| `--auto-generate-object-id-if-not-exist` | `-a`  | `false` | Auto-generate objectIDs                  |
+| `--wait`                                 | `-w`  | `false` | Wait for completion                      |
+
+```bash
+# Import from file
+algolia objects import MOVIES -F movies.ndjson
+
+# Import from stdin
+cat movies.ndjson | algolia objects import MOVIES -F -
+
+# Copy records between indices via pipe
+algolia objects browse SERIES | algolia objects import MOVIES -F -
+
+# Auto-generate IDs
+algolia objects import MOVIES -F movies.ndjson -a
+
+# Wait for indexing to complete
+algolia objects import MOVIES -F movies.ndjson -w
+```
+
+**Input format:** ndjson — one JSON object per line. Each object should have an `objectID` field unless `-a` is used.
+
+**Required ACL:** `addObject`
+
+### `algolia objects delete`
+
+Delete records by ID or by filter.
+
+```bash
+algolia objects delete <index> [--object-ids <ids> | --filters <filter>] [-y] [-w]
+```
+
+| Flag           | Short | Default | Description                |
+|----------------|-------|---------|----------------------------|
+| `--object-ids` |       |         | Comma-separated object IDs |
+| `--filters`    |       |         | Filter expression          |
+| `--confirm`    | `-y`  | `false` | Skip confirmation prompt   |
+| `--wait`       | `-w`  | `false` | Wait for completion        |
+
+You must specify either `--object-ids` or `--filters`.
+
+```bash
+# Delete by IDs
+algolia objects delete MOVIES --object-ids 1,2,3 -y
+
+# Delete by filter
+algolia objects delete MOVIES --filters "type:Scripted" -y
+```
+
+**Required ACL:** `deleteObject`
+
+### `algolia objects update`
+
+Partially update records from an **ndjson** file. Only specified attributes are modified.
+
+```bash
+algolia objects update <index> -F <file> [flags]
+```
+
+| Flag                     | Short | Default | Description                              |
+|--------------------------|-------|---------|------------------------------------------|
+| `--file`                 | `-F`  |         | File path (`-` for stdin) — **required** |
+| `--create-if-not-exists` | `-c`  | `false` | Create records if missing                |
+| `--wait`                 | `-w`  | `false` | Wait for completion                      |
+| `--continue-on-error`    | `-C`  | `false` | Skip invalid records                     |
+
+```bash
+# Partial update
+algolia objects update MOVIES -F updates.ndjson
+
+# Create if not exists
+algolia objects update MOVIES -F updates.ndjson -c
+
+# Wait for completion
+algolia objects update MOVIES -F updates.ndjson -w
+```
+
+**Input format:** ndjson. Each object must have an `objectID`. Supports `_operation` for built-in operations (Add, Remove, Increment, Decrement).
+
+**Required ACL:** `addObject`
+
+---
+
+## Settings
+
+### `algolia settings get`
+
+Get the settings of an index.
+
+```bash
+algolia settings get <index>
+```
+
+```bash
+# Print to terminal
+algolia settings get MOVIES
+
+# Save to file
+algolia settings get MOVIES > settings.json
+```
+
+**Output format:** JSON object.
+
+**Required ACL:** `settings`
+
+### `algolia settings set`
+
+Set individual settings on an index.
+
+```bash
+algolia settings set <index> [--<settingName>=<value>] [-f] [-w]
+```
+
+| Flag                    | Short | Default | Description              |
+|-------------------------|-------|---------|--------------------------|
+| `--forward-to-replicas` | `-f`  | `false` | Apply to replica indices |
+| `--wait`                | `-w`  | `false` | Wait for completion      |
+
+```bash
+# Disable typo tolerance
+algolia settings set MOVIES --typoTolerance="false"
+
+# Forward change to replicas
+algolia settings set MOVIES --typoTolerance="false" -f
+```
+
+**Required ACL:** `editSettings`
+
+### `algolia settings import`
+
+Import settings from a JSON file.
+
+```bash
+algolia settings import <index> -F <file> [-f] [-w]
+```
+
+| Flag                    | Short | Default | Description                              |
+|-------------------------|-------|---------|------------------------------------------|
+| `--file`                | `-F`  |         | File path (`-` for stdin) — **required** |
+| `--forward-to-replicas` | `-f`  | `false` | Apply to replicas                        |
+| `--wait`                | `-w`  | `false` | Wait for completion                      |
+
+```bash
+# Import from file
+algolia settings import MOVIES -F settings.json
+
+# Import and forward to replicas
+algolia settings import MOVIES -F settings.json -f
+
+# Copy settings between indices
+algolia settings get SERIES | algolia settings import MOVIES -F -
+```
+
+**Input format:** Standard JSON (not ndjson).
+
+**Required ACL:** `editSettings`
+
+---
+
+## Rules
+
+### `algolia rules browse`
+
+Export all rules from an index. Aliases: `list`, `l`.
+
+```bash
+algolia rules browse <index>
+```
+
+```bash
+# Print rules
+algolia rules browse MOVIES
+
+# Save to file
+algolia rules browse MOVIES > rules.ndjson
+```
+
+**Output format:** ndjson — one rule per line.
+
+**Required ACL:** `settings`
+
+### `algolia rules import`
+
+Import rules from an **ndjson** file.
+
+```bash
+algolia rules import <index> -F <file> [-f] [-c] [-y] [-w]
+```
+
+| Flag                     | Short | Default | Description                              |
+|--------------------------|-------|---------|------------------------------------------|
+| `--file`                 | `-F`  |         | File path (`-` for stdin) — **required** |
+| `--forward-to-replicas`  | `-f`  | `true`  | Apply to replicas                        |
+| `--clear-existing-rules` | `-c`  | `false` | Delete existing rules first              |
+| `--confirm`              | `-y`  | `false` | Skip confirmation prompt                 |
+| `--wait`                 | `-w`  | `false` | Wait for completion                      |
+
+```bash
+# Import rules
+algolia rules import MOVIES -F rules.ndjson -y
+
+# Replace all existing rules
+algolia rules import MOVIES -F rules.ndjson -c -y
+
+# Copy rules between indices
+algolia rules browse SERIES | algolia rules import MOVIES -F - -y
+
+# Don't forward to replicas
+algolia rules import MOVIES -F rules.ndjson -f=false -y
+```
+
+**Input format:** ndjson. Batched at 1000 rules per request.
+
+**Required ACL:** `editSettings`
+
+### `algolia rules delete`
+
+Delete specific rules by ID.
+
+```bash
+algolia rules delete <index> --rule-ids <ids> [-y] [-w]
+```
+
+| Flag                    | Short | Default | Description                             |
+|-------------------------|-------|---------|-----------------------------------------|
+| `--rule-ids`            |       |         | Comma-separated rule IDs — **required** |
+| `--forward-to-replicas` |       | `false` | Delete from replicas too                |
+| `--confirm`             | `-y`  | `false` | Skip confirmation prompt                |
+| `--wait`                | `-w`  | `false` | Wait for completion                     |
+
+```bash
+# Delete rules
+algolia rules delete MOVIES --rule-ids rule-1,rule-2 -y
+```
+
+**Required ACL:** `editSettings`
+
+---
+
+## Synonyms
+
+### `algolia synonyms browse`
+
+Export all synonyms from an index. Aliases: `list`, `l`.
+
+```bash
+algolia synonyms browse <index>
+```
+
+```bash
+# Print synonyms
+algolia synonyms browse MOVIES
+
+# Save to file
+algolia synonyms browse MOVIES > synonyms.ndjson
+```
+
+**Output format:** ndjson — one synonym per line.
+
+**Required ACL:** `settings`
+
+### `algolia synonyms import`
+
+Import synonyms from an **ndjson** file.
+
+```bash
+algolia synonyms import <index> -F <file> [-f] [-r] [-w]
+```
+
+| Flag                          | Short | Default | Description                              |
+|-------------------------------|-------|---------|------------------------------------------|
+| `--file`                      | `-F`  |         | File path (`-` for stdin) — **required** |
+| `--forward-to-replicas`       | `-f`  | `true`  | Apply to replicas                        |
+| `--replace-existing-synonyms` | `-r`  | `false` | Replace all existing synonyms            |
+| `--wait`                      | `-w`  | `false` | Wait for completion                      |
+
+```bash
+# Import synonyms
+algolia synonyms import MOVIES -F synonyms.ndjson
+
+# Replace all existing synonyms
+algolia synonyms import MOVIES -F synonyms.ndjson -r
+
+# Copy synonyms between indices
+algolia synonyms browse SERIES | algolia synonyms import MOVIES -F -
+
+# Don't forward to replicas
+algolia synonyms import MOVIES -F synonyms.ndjson -f=false
+```
+
+**Input format:** ndjson. Each synonym must have `objectID` and `type` fields.
+
+**Synonym types:**
+
+| Type             | Required Fields                                |
+|------------------|------------------------------------------------|
+| `synonym`        | `synonyms` (array of strings)                  |
+| `oneWaySynonym`  | `input` (string), `synonyms` (array)           |
+| `altCorrection1` | `word` (string), `corrections` (array)         |
+| `altCorrection2` | `word` (string), `corrections` (array)         |
+| `placeholder`    | `placeholder` (string), `replacements` (array) |
+
+**Required ACL:** `editSettings`
+
+### `algolia synonyms delete`
+
+Delete specific synonyms by ID.
+
+```bash
+algolia synonyms delete <index> --synonym-ids <ids> [-y] [-w]
+```
+
+| Flag                    | Short | Default | Description                                |
+|-------------------------|-------|---------|--------------------------------------------|
+| `--synonym-ids`         |       |         | Comma-separated synonym IDs — **required** |
+| `--forward-to-replicas` |       | `false` | Delete from replicas too                   |
+| `--confirm`             | `-y`  | `false` | Skip confirmation prompt                   |
+| `--wait`                | `-w`  | `false` | Wait for completion                        |
+
+```bash
+# Delete synonyms
+algolia synonyms delete MOVIES --synonym-ids syn-1,syn-2 -y
+```
+
+**Required ACL:** `editSettings`
+
+### `algolia synonyms save`
+
+Create or update a single synonym interactively.
+
+```bash
+algolia synonyms save <index> --id <id> [--type <type>] [flags]
+```
+
+| Flag                    | Short | Default   | Description                                                                  |
+|-------------------------|-------|-----------|------------------------------------------------------------------------------|
+| `--id`                  | `-i`  |           | Synonym ID — **required**                                                    |
+| `--type`                | `-t`  | `regular` | Type: `regular`, `oneway`, `altcorrection1`, `altcorrection2`, `placeholder` |
+| `--synonyms`            | `-s`  |           | Comma-separated synonyms (for `regular` and `oneway`)                        |
+| `--input`               | `-n`  |           | Input word (for `oneway`)                                                    |
+| `--placeholder`         | `-l`  |           | Placeholder token (for `placeholder`)                                        |
+| `--replacements`        | `-r`  |           | Comma-separated replacements (for `placeholder`)                             |
+| `--word`                | `-w`  |           | Base word (for `altcorrection1`, `altcorrection2`)                           |
+| `--corrections`         | `-c`  |           | Comma-separated corrections (for `altcorrection1`, `altcorrection2`)         |
+| `--forward-to-replicas` | `-f`  | `false`   | Apply to replicas                                                            |
+
+```bash
+# Regular two-way synonym
+algolia synonyms save MOVIES --id syn-1 --synonyms film,movie,picture
+
+# One-way synonym
+algolia synonyms save MOVIES --id syn-2 --type oneway --input "JS" --synonyms "JavaScript"
+
+# Placeholder
+algolia synonyms save MOVIES --id syn-3 --type placeholder --placeholder "<director>" --replacements "Spielberg,Nolan,Tarantino"
+```
+
+**Required ACL:** `editSettings`
+
+---
+
+## Common Patterns
+
+### Copy data between indices
+
+```bash
+# Copy all records
+algolia objects browse SOURCE_INDEX | algolia objects import DEST_INDEX -F -
+
+# Copy rules
+algolia rules browse SOURCE_INDEX | algolia rules import DEST_INDEX -F - -y
+
+# Copy synonyms
+algolia synonyms browse SOURCE_INDEX | algolia synonyms import DEST_INDEX -F -
+
+# Copy settings
+algolia settings get SOURCE_INDEX | algolia settings import DEST_INDEX -F -
+```
+
+### Export and backup
+
+```bash
+# Full index backup
+algolia objects browse MOVIES > movies_records.ndjson
+algolia settings get MOVIES > movies_settings.json
+algolia rules browse MOVIES > movies_rules.ndjson
+algolia synonyms browse MOVIES > movies_synonyms.ndjson
+```
+
+### Restore from backup
+
+```bash
+# Restore everything
+algolia objects import MOVIES -F movies_records.ndjson -w
+algolia settings import MOVIES -F movies_settings.json -w
+algolia rules import MOVIES -F movies_rules.ndjson -c -y -w
+algolia synonyms import MOVIES -F movies_synonyms.ndjson -r -w
+```
+
+### ndjson format tips
+
+The CLI uses **ndjson** (newline-delimited JSON) for records, rules, and synonyms. Each line is a standalone JSON object:
+
+```
+{"objectID":"1","title":"The Matrix","year":1999}
+{"objectID":"2","title":"Inception","year":2010}
+```
+
+**Do not** wrap in a JSON array. This is wrong:
+
+```json
+[{"objectID":"1"},{"objectID":"2"}]
+```
+
+To convert a JSON array to ndjson:
+
+```bash
+# Using jq
+jq -c '.[]' array.json > records.ndjson
+```

--- a/skills/algolia-cli/references/commands.md
+++ b/skills/algolia-cli/references/commands.md
@@ -41,6 +41,112 @@ algolia profile list
 
 Output columns: NAME, APPLICATION ID, NUMBER OF INDICES, DEFAULT.
 
+### `algolia profile remove`
+
+Remove a profile from the configuration.
+
+```bash
+algolia profile remove <profile> [-y]
+```
+
+| Flag        | Short | Default | Description              |
+|-------------|-------|---------|--------------------------|
+| `--confirm` | `-y`  | `false` | Skip confirmation prompt |
+
+```bash
+# Remove the profile named "staging"
+algolia profile remove staging -y
+```
+
+### `algolia profile setdefault`
+
+Set the default profile.
+
+```bash
+algolia profile setdefault <profile>
+```
+
+```bash
+# Set the default profile to "production"
+algolia profile setdefault production
+```
+
+---
+
+## API Keys
+
+### `algolia apikeys list`
+
+List all API keys for the application.
+
+```bash
+algolia apikeys list
+```
+
+Output columns: KEY, DESCRIPTION, ACL, INDICES, VALIDITY, MAX HITS PER QUERY, MAX QUERIES PER IP PER HOUR, REFERERS, CREATED AT.
+
+**Required ACL:** `admin`
+
+### `algolia apikeys create`
+
+Create a new API key.
+
+```bash
+algolia apikeys create [flags]
+```
+
+| Flag            | Short | Default | Description                                  |
+|-----------------|-------|---------|----------------------------------------------|
+| `--acl`         |       |         | Comma-separated ACLs (search, browse, addObject, deleteObject, listIndexes, deleteIndex, settings, editSettings, analytics, recommendation, usage, logs, seeUnretrievableAttributes) |
+| `--indices`     | `-i`  |         | Index names or patterns (supports `*` wildcard) |
+| `--validity`    | `-u`  | `0`     | Duration after which the key expires (e.g., `1h`, `30m`) |
+| `--referers`    | `-r`  |         | Allowed referrers (supports `*` wildcard)    |
+| `--description` | `-d`  |         | Description to identify the key              |
+
+```bash
+# Create a search-only key for one index
+algolia apikeys create --acl search,browse --indices MOVIES --description "Search & Browse API Key"
+
+# Create a key with multiple indices, a referer restriction, and 1-hour validity
+algolia apikeys create --acl search --indices MOVIES,SERIES --referers "https://example.com" --validity 1h --description "Restricted search key"
+```
+
+**Required ACL:** `admin`
+
+### `algolia apikeys get`
+
+Get details of a specific API key.
+
+```bash
+algolia apikeys get <api-key>
+```
+
+```bash
+# Get API key details
+algolia apikeys get abcdef1234567890
+```
+
+**Output format:** JSON object.
+
+### `algolia apikeys delete`
+
+Delete an API key.
+
+```bash
+algolia apikeys delete <api-key> [-y]
+```
+
+| Flag        | Short | Default | Description              |
+|-------------|-------|---------|--------------------------|
+| `--confirm` | `-y`  | `false` | Skip confirmation prompt |
+
+```bash
+# Delete an API key
+algolia apikeys delete abcdef1234567890 -y
+```
+
+**Required ACL:** `admin`
+
 ---
 
 ## Search

--- a/skills/algolia-cli/references/getting-started.md
+++ b/skills/algolia-cli/references/getting-started.md
@@ -1,0 +1,97 @@
+# Getting Started with the Algolia CLI
+
+## Prerequisites
+
+- **Algolia account** — [Sign up free](https://www.algolia.com/users/sign_up)
+- **Application ID** — Found in [Dashboard → Settings → API Keys](https://dashboard.algolia.com/account/api-keys/all)
+- **Admin API key** — Same location. Required for write operations (import, delete, settings).
+
+## Installation
+
+### macOS (Homebrew)
+
+```bash
+brew install algolia/algolia-cli/algolia
+```
+
+### Linux (deb/rpm)
+
+```bash
+# Debian/Ubuntu
+echo "deb [trusted=yes] https://algolia.github.io/cli/deb/ /" | sudo tee /etc/apt/sources.list.d/algolia-cli.list
+sudo apt update && sudo apt install algolia
+
+# RPM-based (Fedora, RHEL)
+echo "[algolia-cli]
+name=Algolia CLI
+baseurl=https://algolia.github.io/cli/rpm/
+enabled=1
+gpgcheck=0" | sudo tee /etc/yum.repos.d/algolia-cli.repo
+sudo yum install algolia
+```
+
+### Windows (Chocolatey)
+
+```bash
+choco install algolia-cli
+```
+
+### Verify installation
+
+```bash
+algolia --version
+```
+
+## Profile Setup
+
+A profile stores your Algolia credentials locally so you don't need to pass them with every command.
+
+### Create a profile (non-interactive)
+
+```bash
+algolia profile add --name "default" --app-id "YOUR_APP_ID" --api-key "YOUR_ADMIN_API_KEY" --default
+```
+
+> **Important:** Always provide all three flags (`--name`, `--app-id`, `--api-key`) to avoid interactive prompts that require terminal input.
+
+### Verify the profile
+
+```bash
+algolia indices list
+```
+
+This should list the indices in your application.
+
+### List existing profiles
+
+```bash
+algolia profile list
+```
+
+### Configuration file location
+
+Profiles are stored in:
+
+```
+~/.config/algolia/config.toml
+```
+
+### Multiple profiles
+
+You can add multiple profiles for different applications:
+
+```bash
+algolia profile add --name "staging" --app-id "STAGING_ID" --api-key "STAGING_KEY"
+algolia profile add --name "production" --app-id "PROD_ID" --api-key "PROD_KEY" --default
+```
+
+Use `-p <profile>` to target a specific profile:
+
+```bash
+algolia indices list -p staging
+```
+
+## Next Steps
+
+- See the [Command Reference](commands.md) for full syntax and examples.
+- See the [Algolia CLI documentation](https://www.algolia.com/doc/tools/cli/get-started) for additional details.


### PR DESCRIPTION
### Summary

- Add `algolia-cli` skill with `SKILL.md`, CLI command reference, and getting-started guide
- Add `scripts/validate_skills.py` to validate skills against the [agentskills.io spec](https://agentskills.io/specification) (frontmatter fields, body length, link resolution, marketplace.json)
- Add GitHub Actions workflow to run validation on push/PR