### PR TITLE
feat: add algobot-cli skill for Agent Studio management

### DIFF
--- a/skills/algobot-cli/SKILL.md
+++ b/skills/algobot-cli/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: algobot-cli
 description: >-
-  Use this skill whenever a user wants to build or manage AI agents powered by
-  Algolia — including RAG systems, conversational search experiences, genAI
-  content generation (carousels, product descriptions, headers), chatbots,
-  recommendation agents, or any AI feature that uses Algolia as its retrieval
-  backbone. Algolia Agent Studio is the platform for all of these, and algobot
-  is its CLI. Also use when: managing agents (create/list/update/publish/delete),
-  testing agents interactively, deploying across environments (dev/staging/prod),
-  config-as-code workflows, memory/personalization setup, MCP tool integrations
-  (CRM, inventory, external APIs), or automating agent ops in CI/CD. The key
-  signal is building OR managing AI experiences on top of Algolia search or
-  recommendations — even if the user doesn't mention "algobot" or "Agent Studio"
-  by name. Do NOT use for raw Algolia index operations (records, settings,
-  synonyms, rules) — use algolia-cli instead. Do NOT use for pure frontend search
-  UI (InstantSearch components, autocomplete widgets) with no agent layer.
+  ALWAYS use this skill when the user mentions Algolia Agent Studio, algobot,
+  or wants any AI agent / RAG / conversational experience built on Algolia.
+  Covers: RAG systems on Algolia, conversational product discovery, genAI
+  content generation from search results (carousels, product descriptions, page
+  headers), chatbots or recommendation agents using Algolia as retrieval,
+  algobot CLI (install, init, ask, interactive), Agent Studio agent
+  create/update/publish/delete, config-as-code workflows, multi-environment
+  deploy (dev/staging/prod), memory and personalization across sessions,
+  MCP tool integrations (CRM or inventory alongside Algolia), conversation
+  history / GDPR retention, or adding a chat widget alongside InstantSearch.
+  Make sure to use this skill any time the user says "algobot", "Agent Studio",
+  "RAG with Algolia", "conversational experience", "AI agent" + Algolia,
+  "genAI carousel", "chat widget", or asks about building AI features on top
+  of Algolia search — even if they don't say "Agent Studio" or "algobot" by name.
+  Do NOT use for raw Algolia index ops (records, synonyms, settings, facets,
+  rankings) — use algolia-cli instead. Do NOT use for pure frontend search UI
+  (InstantSearch components, autocomplete) with no AI/agent layer.
 license: MIT
 metadata:
   author: algolia

--- a/skills/algobot-cli/SKILL.md
+++ b/skills/algobot-cli/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: algobot-cli
+description: >-
+  Use this skill when a user wants to manage Algolia Agent Studio agents from
+  the terminal — creating, listing, updating, publishing, or deleting agents,
+  testing agents interactively, deploying agents across environments (dev/staging/prod),
+  or automating agent operations in CI/CD pipelines. Also use for config-as-code
+  workflows (scaffolding, mustache templates, dry-run previews) and conversation
+  history management. The key signal is that the user wants to *act on* Agent
+  Studio agents or chat with them via CLI. Do NOT use for Algolia search index
+  operations (records, settings, synonyms, rules) — use algolia-cli instead.
+  Do NOT use for building Agent Studio frontend/UI, or for general LLM/AI tasks
+  unrelated to Algolia Agent Studio.
+license: MIT
+metadata:
+  author: algolia
+  version: "1.0"
+---
+
+# Algobot CLI
+
+Manage and test [Algolia Agent Studio](https://www.algolia.com/products/ai/agent-studio/) agents from the terminal using `algobot`.
+
+## Setup
+
+```bash
+npm install -g algobot-ai
+algobot init                    # Interactive wizard (creates first agent + profile)
+```
+
+Or add a profile manually:
+```bash
+algobot profiles add --name prod --env prod
+# Then enter App ID + Admin API Key when prompted
+```
+
+## When to Use Algobot vs Other Tools
+
+| Need | Use |
+|------|-----|
+| Manage/test Agent Studio agents | **algobot-cli** (this skill) |
+| Algolia search index ops (records, settings, synonyms) | **algolia-cli** |
+| Search queries, analytics, recommendations | **algolia-mcp** |
+
+## Non-Interactive Mode (Critical for Agents)
+
+**The TUI won't render in non-TTY environments** (CI, scripts, agent subprocesses). Use these instead:
+
+```bash
+# One-shot query
+algobot ask "What is your return policy?"
+
+# Scripted multi-turn with ||| separator
+algobot interactive --text "hello ||| list my orders ||| /context"
+
+# Pipe-friendly JSON
+algobot agents list --jq '.[] | .name'
+```
+
+`--jq` is a built-in flag — no need to install jq separately.
+
+## Core Commands
+
+### Agent Management
+
+```bash
+algobot agents list
+algobot agents get <agent-id>
+algobot agents create --name "Support Bot" --model gpt-4o
+algobot agents update <agent-id> --name "New Name"
+algobot agents publish <agent-id>
+algobot agents unpublish <agent-id>
+algobot agents delete <agent-id>
+algobot agents copy <id> --from-env dev --to-env prod
+algobot agents export <agent-id>             # Export config to JSON
+```
+
+### Chatting with an Agent
+
+```bash
+algobot ask "Find wireless headphones under $100"
+algobot --profile staging ask "hello"        # Target specific environment
+algobot --verbose ask "debug this"           # Show full HTTP traces
+```
+
+### Profile / Environment Management
+
+```bash
+algobot profiles list
+algobot profiles add --name dev --env dev
+algobot profiles setdefault prod
+algobot profiles show prod                   # JSON output
+
+# Per-command override
+algobot --profile prod agents list
+algobot --env dev agents list               # Uses default profile for that env
+```
+
+## Config-as-Code Workflow
+
+Version-control agent definitions with mustache templates. Ideal for repeatable deployments (events, teams, multi-region).
+
+```bash
+# 1. Scaffold from an existing agent
+algobot agents scaffold <agent-id>           # → agent-config.json + PROMPT.md
+
+# 2. Preview resolved config (API-level kill switch — mutations blocked)
+algobot --dry-run agents create --config agent-config.json --var event="Spring 2026"
+
+# 3. Deploy
+algobot agents create --config agent-config.json --var event_name="Spring 2026" --var event_id="spring-2026"
+
+# 4. Update + publish in one step
+algobot agents update <id> --config agent-config.json --var event_name="Summer 2026" --publish
+```
+
+`--dry-run` is enforced at the API layer, not just a flag check — safe to use in previews.
+
+`{{key}}` placeholders resolve differently by field type:
+- JSON config fields: JSON-safe escaping
+- Instructions (`.md` files): raw substitution
+
+## Live Development
+
+```bash
+algobot agents watch patch.json             # Auto-apply patches on file change (like hot reload)
+```
+
+## Global Flags
+
+| Flag | Effect |
+|------|--------|
+| `--env dev\|staging\|prod\|local` | Target environment |
+| `--profile <name>` | Use named profile |
+| `--dry-run` | Preview without mutating (API-enforced) |
+| `--verbose` | Full HTTP logs |
+| `--jq '<expr>'` | Filter JSON output |
+| `--confirm` | Skip exec tool confirmations |
+
+## Gotchas
+
+- **TUI requires TTY.** `algobot` with no args launches the TUI — it hangs in scripts. Always use `ask` or `--text` in non-interactive contexts.
+- **Exit codes are 0/1 only** in v2.0. Can't distinguish "not found" from "auth error" by exit code — parse stderr if needed.
+- **`--output json` missing on most commands** in v2.0. Use `--jq` or rely on JSON-structured stdout where available.
+- **`algobot init` is interactive.** Don't use in CI — use `profiles add` with flags instead.
+- **Auth stored in `~/.algobot-cookie`** (AES-256-GCM). Run `algobot auth show` to inspect current credentials.
+- **`--config` auto-discovers `agent-config.json`** in cwd. Explicit path: `--config path/to/config.json`.
+
+## Reference Docs
+
+- [Command Reference](references/commands.md) — Full flags for every command
+- [Config-as-Code Guide](references/config-as-code.md) — Templates, variables, multi-env patterns

--- a/skills/algobot-cli/SKILL.md
+++ b/skills/algobot-cli/SKILL.md
@@ -1,25 +1,37 @@
 ---
 name: algobot-cli
 description: >-
-  Use this skill when a user wants to manage Algolia Agent Studio agents from
-  the terminal — creating, listing, updating, publishing, or deleting agents,
-  testing agents interactively, deploying agents across environments (dev/staging/prod),
-  or automating agent operations in CI/CD pipelines. Also use for config-as-code
-  workflows (scaffolding, mustache templates, dry-run previews) and conversation
-  history management. The key signal is that the user wants to *act on* Agent
-  Studio agents or chat with them via CLI. Do NOT use for Algolia search index
-  operations (records, settings, synonyms, rules) — use algolia-cli instead.
-  Do NOT use for building Agent Studio frontend/UI, or for general LLM/AI tasks
-  unrelated to Algolia Agent Studio.
+  Use this skill whenever a user wants to build or manage AI agents powered by
+  Algolia — including RAG systems, conversational search experiences, genAI
+  content generation (carousels, product descriptions, headers), chatbots,
+  recommendation agents, or any AI feature that uses Algolia as its retrieval
+  backbone. Algolia Agent Studio is the platform for all of these, and algobot
+  is its CLI. Also use when: managing agents (create/list/update/publish/delete),
+  testing agents interactively, deploying across environments (dev/staging/prod),
+  config-as-code workflows, memory/personalization setup, MCP tool integrations
+  (CRM, inventory, external APIs), or automating agent ops in CI/CD. The key
+  signal is building OR managing AI experiences on top of Algolia search or
+  recommendations — even if the user doesn't mention "algobot" or "Agent Studio"
+  by name. Do NOT use for raw Algolia index operations (records, settings,
+  synonyms, rules) — use algolia-cli instead. Do NOT use for pure frontend search
+  UI (InstantSearch components, autocomplete widgets) with no agent layer.
 license: MIT
 metadata:
   author: algolia
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Algobot CLI
 
-Manage and test [Algolia Agent Studio](https://www.algolia.com/products/ai/agent-studio/) agents from the terminal using `algobot`.
+[Algolia Agent Studio](https://www.algolia.com/products/ai/agent-studio/) is Algolia's platform for building AI agents — RAG systems, conversational experiences, genAI content generation — with Algolia search and recommendations as the retrieval backbone. `algobot` (`npm install -g algobot-ai`) is its CLI for creating, testing, and deploying agents.
+
+## When to Use Algobot vs Other Tools
+
+| Need | Use |
+|------|-----|
+| Build/manage AI agents on Algolia (RAG, chatbot, genAI UI) | **algobot-cli** (this skill) |
+| Algolia search index ops (records, settings, synonyms) | **algolia-cli** |
+| Search queries, analytics, recommendations | **algolia-mcp** |
 
 ## Setup
 
@@ -28,36 +40,22 @@ npm install -g algobot-ai
 algobot init                    # Interactive wizard (creates first agent + profile)
 ```
 
-Or add a profile manually:
+Or add a profile manually (CI-safe, non-interactive):
 ```bash
 algobot profiles add --name prod --env prod
-# Then enter App ID + Admin API Key when prompted
 ```
-
-## When to Use Algobot vs Other Tools
-
-| Need | Use |
-|------|-----|
-| Manage/test Agent Studio agents | **algobot-cli** (this skill) |
-| Algolia search index ops (records, settings, synonyms) | **algolia-cli** |
-| Search queries, analytics, recommendations | **algolia-mcp** |
 
 ## Non-Interactive Mode (Critical for Agents)
 
 **The TUI won't render in non-TTY environments** (CI, scripts, agent subprocesses). Use these instead:
 
 ```bash
-# One-shot query
-algobot ask "What is your return policy?"
-
-# Scripted multi-turn with ||| separator
-algobot interactive --text "hello ||| list my orders ||| /context"
-
-# Pipe-friendly JSON
-algobot agents list --jq '.[] | .name'
+algobot ask "What is your return policy?"                    # One-shot
+algobot interactive --text "hello ||| list my orders ||| /context"  # Multi-turn
+algobot agents list --jq '.[] | .name'                       # JSON filtering
 ```
 
-`--jq` is a built-in flag — no need to install jq separately.
+`--jq` is built-in — no need to install jq separately.
 
 ## Core Commands
 
@@ -72,7 +70,6 @@ algobot agents publish <agent-id>
 algobot agents unpublish <agent-id>
 algobot agents delete <agent-id>
 algobot agents copy <id> --from-env dev --to-env prod
-algobot agents export <agent-id>             # Export config to JSON
 ```
 
 ### Chatting with an Agent
@@ -89,41 +86,45 @@ algobot --verbose ask "debug this"           # Show full HTTP traces
 algobot profiles list
 algobot profiles add --name dev --env dev
 algobot profiles setdefault prod
-algobot profiles show prod                   # JSON output
-
-# Per-command override
 algobot --profile prod agents list
-algobot --env dev agents list               # Uses default profile for that env
+algobot --env dev agents list
 ```
 
 ## Config-as-Code Workflow
 
-Version-control agent definitions with mustache templates. Ideal for repeatable deployments (events, teams, multi-region).
+Version-control agent definitions with mustache templates — ideal for repeatable deployments across events, teams, or environments.
 
 ```bash
 # 1. Scaffold from an existing agent
 algobot agents scaffold <agent-id>           # → agent-config.json + PROMPT.md
 
-# 2. Preview resolved config (API-level kill switch — mutations blocked)
+# 2. Preview (API-level kill switch — mutations blocked by construction)
 algobot --dry-run agents create --config agent-config.json --var event="Spring 2026"
 
 # 3. Deploy
-algobot agents create --config agent-config.json --var event_name="Spring 2026" --var event_id="spring-2026"
+algobot agents create --config agent-config.json --var event_name="Spring 2026"
 
 # 4. Update + publish in one step
 algobot agents update <id> --config agent-config.json --var event_name="Summer 2026" --publish
 ```
 
-`--dry-run` is enforced at the API layer, not just a flag check — safe to use in previews.
+`{{key}}` in JSON fields: JSON-safe escaping. In `.md` instructions: raw substitution.
 
-`{{key}}` placeholders resolve differently by field type:
-- JSON config fields: JSON-safe escaping
-- Instructions (`.md` files): raw substitution
+## Agent Studio Capabilities (via agent config)
+
+Beyond basic chat, Agent Studio agents support:
+
+- **Tools**: Algolia Search, Algolia Browse, Algolia Recommend, client-side tools, and [MCP tools](https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/tools/mcp-tools) (connect CRMs, inventory systems, external APIs alongside Algolia). Manage with `algobot tools list/add/remove`
+- **Memory**: Semantic (facts/preferences) and episodic (past interactions) memory across sessions, using `algolia_memorize`, `algolia_ponder`, and `algolia_memory_search` tools. Configure retrieval mode (preload vs preflight) in agent config.
+- **Conversation storage**: Persistent history with configurable retention — see `algobot conversations` for export/delete
+- **Experimental**: Citation markers `[1][2]` on responses, date injection, response caching — enable in agent config
+
+Use `algobot agents scaffold` to inspect/edit these settings, `algobot --dry-run` to preview before applying.
 
 ## Live Development
 
 ```bash
-algobot agents watch patch.json             # Auto-apply patches on file change (like hot reload)
+algobot agents watch patch.json             # Auto-apply patches on file change
 ```
 
 ## Global Flags
@@ -139,12 +140,13 @@ algobot agents watch patch.json             # Auto-apply patches on file change 
 
 ## Gotchas
 
-- **TUI requires TTY.** `algobot` with no args launches the TUI — it hangs in scripts. Always use `ask` or `--text` in non-interactive contexts.
-- **Exit codes are 0/1 only** in v2.0. Can't distinguish "not found" from "auth error" by exit code — parse stderr if needed.
-- **`--output json` missing on most commands** in v2.0. Use `--jq` or rely on JSON-structured stdout where available.
+- **TUI requires TTY.** `algobot` with no args launches the TUI — hangs in scripts. Always use `ask` or `--text` in non-interactive contexts.
+- **Exit codes are 0/1 only** in v2.0. Can't distinguish "not found" from "auth error" — parse stderr if needed.
+- **`--output json` missing on most commands** in v2.0. Use `--jq` or JSON-structured stdout.
 - **`algobot init` is interactive.** Don't use in CI — use `profiles add` with flags instead.
-- **Auth stored in `~/.algobot-cookie`** (AES-256-GCM). Run `algobot auth show` to inspect current credentials.
-- **`--config` auto-discovers `agent-config.json`** in cwd. Explicit path: `--config path/to/config.json`.
+- **Auth stored in `~/.algobot-cookie`** (AES-256-GCM). Inspect with `algobot auth show`.
+- **`--config` auto-discovers `agent-config.json`** in cwd. Explicit: `--config path/to/config.json`.
+- **algobot = dev/deploy tool; REST API = production invocation.** Use algobot to build and publish agents; call the Agent Studio completions API directly from your app. Don't guess the endpoint URL — run `algobot agents get <id>` to retrieve it, or check the Agent Studio dashboard.
 
 ## Reference Docs
 

--- a/skills/algobot-cli/SKILL.md
+++ b/skills/algobot-cli/SKILL.md
@@ -1,23 +1,18 @@
 ---
 name: algobot-cli
 description: >-
-  ALWAYS use this skill when the user mentions Algolia Agent Studio, algobot,
-  or wants any AI agent / RAG / conversational experience built on Algolia.
-  Covers: RAG systems on Algolia, conversational product discovery, genAI
-  content generation from search results (carousels, product descriptions, page
-  headers), chatbots or recommendation agents using Algolia as retrieval,
-  algobot CLI (install, init, ask, interactive), Agent Studio agent
-  create/update/publish/delete, config-as-code workflows, multi-environment
-  deploy (dev/staging/prod), memory and personalization across sessions,
-  MCP tool integrations (CRM or inventory alongside Algolia), conversation
-  history / GDPR retention, or adding a chat widget alongside InstantSearch.
-  Make sure to use this skill any time the user says "algobot", "Agent Studio",
-  "RAG with Algolia", "conversational experience", "AI agent" + Algolia,
-  "genAI carousel", "chat widget", or asks about building AI features on top
-  of Algolia search — even if they don't say "Agent Studio" or "algobot" by name.
-  Do NOT use for raw Algolia index ops (records, synonyms, settings, facets,
-  rankings) — use algolia-cli instead. Do NOT use for pure frontend search UI
-  (InstantSearch components, autocomplete) with no AI/agent layer.
+  Use for anything AI/agent/conversational built on Algolia: algobot CLI,
+  Agent Studio, RAG systems, conversational product discovery, genAI content
+  generation from search results (carousels, descriptions, headers), chatbots
+  or recommendation agents using Algolia as retrieval, config-as-code
+  workflows, multi-environment deploy (dev/staging/prod), memory and
+  personalization, MCP tool integrations, conversation history / GDPR
+  retention, or adding a chat widget alongside InstantSearch. Trigger on:
+  "algobot", "Agent Studio", "RAG with Algolia", "conversational experience",
+  "AI agent" + Algolia, "genAI carousel", "chat widget", or building AI
+  features on top of Algolia search. Do NOT use for raw index ops (records,
+  synonyms, settings) — use algolia-cli. Do NOT use for pure frontend search
+  UI (InstantSearch, autocomplete) with no AI/agent layer.
 license: MIT
 metadata:
   author: algolia

--- a/skills/algobot-cli/evals/evals.json
+++ b/skills/algobot-cli/evals/evals.json
@@ -1,0 +1,114 @@
+{
+  "skill_name": "algobot-cli",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I want to build a RAG system with Algolia. I already have a product catalog indexed. I want an AI agent that answers customer questions by searching the index and giving contextual answers. How do I get started?",
+      "expected_output": "Explains that Algolia Agent Studio is the platform for this, introduces algobot as the CLI, and walks through: install algobot-ai, run algobot init to create the agent, configure it to use the search index as a tool, and how to test it with algobot ask.",
+      "files": [],
+      "assertions": [
+        "Mentions Algolia Agent Studio as the platform for building the RAG agent",
+        "References algobot or algobot-ai as the CLI tool",
+        "Includes at least one concrete algobot command (e.g. algobot init, algobot agents create)",
+        "Does NOT suggest LangChain or LlamaIndex as the primary solution",
+        "Explains how the agent connects to the Algolia search index (tools/retrieval layer)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I'm building a conversational product discovery experience for my e-commerce site using Algolia. Users should chat naturally and get product recommendations. I've heard about Agent Studio — walk me through creating and testing an agent.",
+      "expected_output": "Uses the skill to walk through: install algobot-ai, algobot init wizard, create an agent with the right tools/model, test it interactively with algobot ask or TUI, and notes on non-interactive mode for CI.",
+      "files": [],
+      "assertions": [
+        "Introduces algobot CLI as the tool for creating and managing Agent Studio agents",
+        "Includes algobot install command (npm install -g algobot-ai)",
+        "Shows how to test the agent with algobot ask or algobot interactive --text",
+        "Mentions the TUI/TTY gotcha (hangs in non-interactive environments)"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I want to generate AI-powered product descriptions for a carousel on our search results page. The idea: user searches 'summer dress', we get top 10 Algolia results, then an AI agent generates a themed header and intro text. How would I build this with algobot/Agent Studio?",
+      "expected_output": "Explains using Agent Studio to build the generative layer on top of Algolia search. Covers creating an agent that takes search results as context, using algobot for config-as-code so the carousel agent can be deployed consistently, and how algobot ask or the API handles the generation step.",
+      "files": [],
+      "assertions": [
+        "Frames Agent Studio as the generative layer on top of Algolia search results",
+        "References algobot CLI commands for creating or deploying the carousel agent",
+        "Distinguishes algobot (dev/deploy tool) from the REST API (production invocation)",
+        "Does NOT fabricate API endpoints — uses commands from the skill or acknowledges uncertainty"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I built an algobot agent in dev and it works great. Now I need to promote it to production and keep the config in version control so the team can deploy it reproducibly.",
+      "expected_output": "Walks through: algobot agents scaffold to export the config, editing agent-config.json + PROMPT.md, using --var for environment differences, algobot agents copy --from-env dev --to-env prod, and the full config-as-code deploy workflow with --dry-run before committing.",
+      "files": [],
+      "assertions": [
+        "Uses algobot agents scaffold (not agents export) to generate the config files",
+        "Mentions agent-config.json and PROMPT.md as the version-controlled artifacts",
+        "Shows --dry-run before deploying to production",
+        "Covers algobot agents copy --from-env dev --to-env prod OR config-based deploy with --publish"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I want my customer support agent to remember user preferences across sessions — like their preferred language, past issues, and whether they've already tried the standard troubleshooting steps. How does Agent Studio handle memory?",
+      "expected_output": "Explains Agent Studio's two memory types (semantic for facts/preferences, episodic for past interactions), the memory tools (algolia_memorize, algolia_ponder, algolia_memory_search), retrieval modes (preload vs preflight), and how to configure memory in the agent config.",
+      "files": [],
+      "assertions": [
+        "Explains Agent Studio has built-in memory (semantic and/or episodic)",
+        "Mentions at least one memory tool (algolia_memorize, algolia_ponder, or algolia_memory_search)",
+        "Explains that memory persists across conversations for the same user",
+        "References algobot as the tool to configure or test the memory-enabled agent"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "We're in Europe and need our AI agent's conversation history to be GDPR-compliant — configurable retention, user data deletion on request, and auditability. Can Agent Studio handle this?",
+      "expected_output": "Confirms Agent Studio has built-in GDPR-aligned conversation storage with configurable retention policies and automated cleanup. Explains how algobot can be used to manage and export conversation history, and notes this is a beta feature.",
+      "files": [],
+      "assertions": [
+        "Confirms Agent Studio has GDPR-aligned conversation storage",
+        "Mentions configurable retention policies or automated data cleanup",
+        "Does NOT fabricate compliance certifications Agent Studio doesn't have",
+        "References algobot conversations commands (list, export, delete) for auditability"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "My agent needs to pull data from both Algolia search AND our CRM (HubSpot) to give complete answers. Like: search for a product, then check the CRM for the customer's purchase history. Is that possible in Agent Studio?",
+      "expected_output": "Explains Agent Studio's MCP tools support, which allows connecting external services like CRMs alongside Algolia search. References the Algolia MCP Server and third-party MCP integrations, and shows how algobot tools commands are used to configure the tool set.",
+      "files": [],
+      "assertions": [
+        "Explains Agent Studio supports MCP tools for external integrations beyond Algolia",
+        "Mentions the ability to combine Algolia search with third-party data sources (CRM, inventory, etc.)",
+        "References algobot tools commands for managing the agent's tool configuration",
+        "Does not suggest building a custom LLM orchestration layer when Agent Studio MCP tools suffice"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "I have InstantSearch.js already on my site. I want to add a conversational chat widget alongside the search results — so users can either search normally OR ask the agent questions. How do I wire this up with Agent Studio?",
+      "expected_output": "Explains Agent Studio's native InstantSearch.js integration (compatible with ai-sdk v5), how the chat widget can live alongside InstantSearch results, and how algobot is used to create and publish the backing agent that powers the widget.",
+      "files": [],
+      "assertions": [
+        "Explains that Agent Studio agent and InstantSearch can coexist in the same UI (complementary, not competing)",
+        "References algobot to create and publish the backing agent",
+        "Explains algobot is the dev/deploy tool and the app calls the completions API directly for production",
+        "Does NOT suggest replacing InstantSearch with the agent"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "I want to add source citations to my agent's responses — like when it says 'this product is on sale', it should show [1] linking to the search result that confirmed it. Is this possible?",
+      "expected_output": "Explains Agent Studio's experimental citation markers feature, which adds [1], [2] references to responses based on search tool call results. Notes it's experimental, explains how to enable it in agent config, and uses algobot to update the agent.",
+      "files": [],
+      "assertions": [
+        "Mentions Agent Studio's citation markers as an experimental feature",
+        "Explains citations are based on search results from tool calls",
+        "Notes the experimental/beta status appropriately",
+        "References algobot agents update or patch to enable the feature in the agent config"
+      ]
+    }
+  ]
+}

--- a/skills/algobot-cli/references/commands.md
+++ b/skills/algobot-cli/references/commands.md
@@ -1,0 +1,117 @@
+# Algobot CLI — Command Reference
+
+## agents
+
+```bash
+algobot agents list [--jq '<expr>']
+algobot agents get <agent-id>
+algobot agents create --name <name> --model <model> [--config <file>] [--var k=v]
+algobot agents update <agent-id> [--name <name>] [--model <model>] [--config <file>] [--var k=v] [--publish]
+algobot agents patch <agent-id> --file <json-file>
+algobot agents delete <agent-id>
+algobot agents publish <agent-id>
+algobot agents unpublish <agent-id>
+algobot agents export <agent-id>                      # JSON to stdout
+algobot agents copy <id> --from-env <env> --to-env <env>
+algobot agents scaffold <agent-id>                    # → agent-config.json + PROMPT.md
+algobot agents watch <patch-file>                     # Live reload on file change
+algobot agents edit                                   # Open in $EDITOR
+```
+
+## ask / interactive
+
+```bash
+algobot ask "<prompt>"                                # One-shot, streams response
+algobot interactive                                   # TUI (requires TTY)
+algobot interactive --text "<prompt> ||| <prompt2>"  # Scripted multi-turn
+```
+
+## profiles
+
+```bash
+algobot profiles list
+algobot profiles add --name <name> --env <dev|staging|prod>
+algobot profiles show [name]                          # JSON output
+algobot profiles setdefault <name>
+algobot profiles remove <name>
+```
+
+## providers
+
+```bash
+algobot providers list
+algobot providers get <provider-id>
+algobot providers create --name <name>
+algobot providers patch <provider-id> --file <json-file>
+algobot providers delete <provider-id>
+```
+
+## tools
+
+```bash
+algobot tools list
+algobot tools add --tool-file <json-file>
+algobot tools remove <toolType>
+```
+
+## history / conversations
+
+```bash
+algobot history search "<query>"
+algobot history recent [--short]
+algobot history stats
+algobot history interactive                           # Fuzzy search (requires TTY)
+algobot history clear
+
+algobot conversations list [--short]
+algobot conversations get <id>
+algobot conversations search "<query>"
+algobot conversations export
+algobot conversations delete <id>
+```
+
+## auth / permissions
+
+```bash
+algobot auth show                                     # Current credentials
+algobot permissions list
+algobot permissions init
+algobot permissions add <path>
+algobot permissions test --command "<cmd>"
+algobot permissions logs
+```
+
+## Other
+
+```bash
+algobot init                                          # Interactive first-time wizard
+algobot version
+```
+
+## Environment URLs
+
+| Env | Base URL |
+|-----|----------|
+| `prod` | `https://agent-studio.eu.algolia.com` |
+| `staging` | `https://agent-studio.staging.eu.algolia.com` |
+| `dev` | `https://conversational-ai-dev.algolia.com` |
+| `local` | `http://localhost:8000` |
+
+## TUI Slash Commands (interactive mode only)
+
+```
+/config          Edit agent in $EDITOR
+/model           Switch model interactively
+/provider        Switch LLM provider
+/temperature     Adjust creativity (0.0–2.0)
+/reasoning       Set reasoning effort: minimal|low|medium|high
+/verbosity       Set response verbosity: low|medium|high
+/compact         Summarize conversation to free context
+/tools           Show agent tools
+/context         Token usage stats
+/verbose         Toggle HTTP logging
+/search <q>      Search conversation history
+/conversations   List recent conversations
+/reset           Clear conversation context
+/help            Full command list
+```

--- a/skills/algobot-cli/references/config-as-code.md
+++ b/skills/algobot-cli/references/config-as-code.md
@@ -1,0 +1,102 @@
+# Config-as-Code Guide
+
+Version-control agent definitions as files. Deploy repeatable agents across environments, events, or teams.
+
+## File Structure
+
+```
+my-agent/
+├── agent-config.json    # Agent definition (model, tools, settings)
+└── PROMPT.md            # Agent instructions (referenced from config)
+```
+
+## Scaffolding
+
+Generate from an existing agent:
+
+```bash
+algobot agents scaffold <agent-id>
+```
+
+Produces `agent-config.json` with the agent's current config, and `PROMPT.md` if instructions exist.
+
+## agent-config.json Format
+
+```json
+{
+  "name": "{{event_name}} Support Bot",
+  "model": "gpt-4o",
+  "instructions": "PROMPT.md",
+  "tools": [...],
+  "indexName": "{{index_name}}"
+}
+```
+
+- `"instructions": "PROMPT.md"` — loads instructions from the referenced `.md` file
+- `{{key}}` — mustache placeholder, resolved via `--var key=value`
+- JSON config fields: JSON-safe escaping. Instructions (`.md`): raw substitution.
+
+## Template Variables
+
+```bash
+# Single variable
+algobot agents create --config agent-config.json --var event_name="Spring 2026"
+
+# Multiple variables
+algobot agents create --config agent-config.json \
+  --var event_name="Spring 2026" \
+  --var event_id="spring-2026" \
+  --var index_name="products_spring"
+
+# CLI flags override config file
+algobot agents create --config agent-config.json --name "Override Name" --var event="Spring"
+```
+
+## Dry Run
+
+Preview resolved config before deploying — mutations blocked at API layer:
+
+```bash
+algobot --dry-run agents create --config agent-config.json --var event="Spring"
+# Shows resolved config, makes no network mutations
+```
+
+## Multi-Environment Workflow
+
+```bash
+# Deploy to dev first
+algobot --profile dev agents create --config agent-config.json --var env=dev
+
+# Promote to staging
+algobot --profile staging agents create --config agent-config.json --var env=staging
+
+# Copy an agent between environments directly
+algobot agents copy <agent-id> --from-env dev --to-env prod
+
+# Update + publish in one step
+algobot --profile prod agents update <id> --config agent-config.json --var env=prod --publish
+```
+
+## Live Reload (Development)
+
+Watch a patch file and auto-apply on save:
+
+```bash
+algobot agents watch patch.json
+```
+
+Patch file is a JSON object with the fields to update. Useful for rapid iteration on model, instructions, tools.
+
+## CI/CD Pattern
+
+```bash
+# In CI (non-interactive):
+algobot profiles add --name ci --env prod    # One-time setup (use env vars for creds)
+algobot --profile ci --dry-run agents create --config agent-config.json --var release=v2
+algobot --profile ci agents create --config agent-config.json --var release=v2 --publish
+```
+
+Credentials via environment (CI-safe, no interactive prompts):
+```bash
+ALGOBOT_APP_ID=XXX ALGOBOT_API_KEY=YYY algobot agents list
+```


### PR DESCRIPTION
## Summary

New skill for managing Algolia Agent Studio agents from the terminal via `algobot` (npm: `algobot-ai`).

- **Triggers on**: create/list/update/publish/delete agents, chat with agents, config-as-code deployments, multi-env management
- **Does NOT trigger on**: Algolia search index ops (algolia-cli), general LLM tasks

## What's included

- `SKILL.md` (152 lines) — setup, non-interactive mode gotchas, core commands, config-as-code workflow, global flags
- `references/commands.md` — full command reference for every subcommand
- `references/config-as-code.md` — templates, variables, multi-env, CI/CD patterns

## Key gotchas captured

- TUI requires TTY — agents must use `ask` or `--text` mode
- `--dry-run` is API-layer enforced, not just a flag
- `--jq` is built-in, no need to pipe to jq
- Exit codes are 0/1 only in v2.0