### PR TITLE
fix: register algobot-cli in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,6 +26,15 @@
       "skills": [
         "./skills/algolia-cli"
       ]
+    },
+    {
+      "name": "algobot-cli",
+      "description": "Use for anything AI/agent/conversational built on Algolia: algobot CLI, Agent Studio, RAG systems, conversational product discovery, genAI content generation from search results (carousels, descriptions, headers), chatbots or recommendation agents using Algolia as retrieval, config-as-code workflows, multi-environment deploy (dev/staging/prod), memory and personalization, MCP tool integrations, conversation history / GDPR retention, or adding a chat widget alongside InstantSearch. Do NOT use for raw index ops (records, synonyms, settings) — use algolia-cli. Do NOT use for pure frontend search UI (InstantSearch, autocomplete) with no AI/agent layer.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/algobot-cli"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `algobot-cli` was merged in #7 but never added to `.claude-plugin/marketplace.json`
- Claude Code `/plugins` reads `marketplace.json` for discovery — skill was invisible to users
- Adds the missing entry so `algobot-cli` appears in `/plugins` alongside `algolia-mcp` and `algolia-cli`

## Test plan

- [ ] Run `/plugins` in Claude Code — verify `algobot-cli` appears in the list
- [ ] Install via `npx skills add algolia/skills --skill algobot-cli` — should resolve correctly