### PR TITLE
chore: contribution guardrails — PR template + evals gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What does this skill do?
+
+<!-- One sentence: what problem does it solve, for whom? -->
+
+## Checklist
+
+- [ ] `python3 scripts/validate_skills.py .` passes (0 errors)
+- [ ] Skill description is under 1024 chars and includes WHEN and WHEN NOT to trigger
+- [ ] `evals/evals.json` exists with at least 1 realistic prompt
+- [ ] Skill is self-contained — no `../other-skill/` references
+- [ ] Registered in `.claude-plugin/marketplace.json` (new skills only)
+- [ ] Goes in `skills/` here if useful to customers; internal-only skills → `algolia/internal-skills`

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -204,6 +204,24 @@ def validate_marketplace(root: Path) -> None:
     if all_exist:
         report.pass_(ctx, "skill paths exist")
 
+    # Inverse check: every skill on disk must be registered in marketplace.json
+    skills_dir = root / "skills"
+    if skills_dir.exists():
+        registered = set()
+        for plugin in data.get("plugins", []):
+            for skill_path in plugin.get("skills", []):
+                resolved = (root / skill_path).resolve()
+                registered.add(resolved)
+
+        all_registered = True
+        for skill_dir in sorted(d for d in skills_dir.iterdir() if d.is_dir()):
+            if skill_dir.resolve() not in registered:
+                report.fail_(ctx, f"unregistered skill: {skill_dir.name} exists in skills/ but is not listed in marketplace.json")
+                all_registered = False
+
+        if all_registered:
+            report.pass_(ctx, "all skills registered in marketplace.json")
+
 
 def main() -> None:
     root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -175,6 +175,22 @@ def validate_skill(skill_dir: Path) -> None:
     validate_body_length(skill_dir, body)
     validate_links(skill_dir, body)
 
+    # Evals coverage — hard fail if missing entirely
+    evals_file = skill_dir / "evals" / "evals.json"
+    if not evals_file.exists():
+        report.fail_(ctx, "evals/evals.json missing — add at least 1 example prompt (see README)")
+    else:
+        try:
+            data = json.loads(evals_file.read_text(encoding="utf-8"))
+            evals = data.get("evals", data) if isinstance(data, dict) else data
+            count = len(evals) if isinstance(evals, list) else 0
+            if count == 0:
+                report.fail_(ctx, "evals/evals.json has 0 prompts — add at least 1")
+            else:
+                report.pass_(ctx, f"evals ({count} prompt(s))")
+        except (json.JSONDecodeError, Exception) as e:
+            report.fail_(ctx, f"evals/evals.json invalid JSON: {e}")
+
 
 def validate_marketplace(root: Path) -> None:
     ctx = "marketplace.json"


### PR DESCRIPTION
Mirrors the guardrails added to `algolia/internal-skills` (PR #23) for consistency.

## What's in

- **PR template** — checklist on every new PR: validate passes, description under 1024 chars, evals exist, registered in marketplace.json
- **Evals gate** (`validate_skills.py`) — hard-fail if `evals/evals.json` is missing or empty. Structural check only ("did you write anything?") — no API key needed.

## What needs an admin (can't do with MAINTAIN)

- **Branch protection on main** — requires org admin. Config to apply:
  - Required status check: `Validate Skills`
  - 1 approving review required
  - Dismiss stale reviews: true
  - No force-push, no direct deletion

@aallam  can you enable branch protection once this merges? 🙏