### PR TITLE
chore(CLI): update skill and available commands

### DIFF
--- a/skills/algolia-cli/SKILL.md
+++ b/skills/algolia-cli/SKILL.md
@@ -28,6 +28,7 @@ Manage Algolia search infrastructure from the terminal using the `algolia` CLI.
 |------|-----|
 | Write/modify data (import, delete, update records) | **algolia-cli** (this skill) |
 | Manage configuration (settings, rules, synonyms) | **algolia-cli** (this skill) |
+| Auth (login, logout, signup via OAuth)                 | **algolia-cli** (this skill) |
 | Admin operations (API keys, profiles, index copy/move) | **algolia-cli** (this skill) |
 | Backup/restore indices | **algolia-cli** (this skill) |
 | Search queries and view results | **algolia-mcp** |
@@ -40,7 +41,19 @@ Manage Algolia search infrastructure from the terminal using the `algolia` CLI.
 
 Run `/algolia-cli:setup` to install the CLI and configure a profile, or follow [Getting Started](references/getting-started.md).
 
+**Tip:** `algolia auth login` is the easiest way to set up credentials — it handles OAuth sign-in and profile creation in one step. Use `algolia profile add` for non-interactive / CI setups where you already have an API key.
+
 ## Command Quick Reference
+
+### Auth
+
+| Task                        | Command                                            |
+|-----------------------------|----------------------------------------------------|
+| Sign in (opens browser)     | `algolia auth login`                               |
+| Sign in (select app by name)| `algolia auth login --app-name "My App" --default` |
+| Sign in (no browser / SSH)  | `algolia auth login --no-browser`                  |
+| Sign out                    | `algolia auth logout`                              |
+| Create new account          | `algolia auth signup`                              |
 
 ### Profile
 
@@ -50,6 +63,15 @@ Run `/algolia-cli:setup` to install the CLI and configure a profile, or follow [
 | List profiles                 | `algolia profile list`                                                             |
 | Remove a profile              | `algolia profile remove "<name>" -y`                                               |
 | Set default profile           | `algolia profile setdefault "<name>"`                                              |
+
+### Application
+
+| Task                              | Command                                                          |
+|-----------------------------------|------------------------------------------------------------------|
+| List applications                 | `algolia application list`                                       |
+| Create application                | `algolia application create --name "My App" --region CA`         |
+| Create (non-interactive, dry-run) | `algolia application create --name "My App" --region CA --dry-run` |
+| Switch active application         | `algolia application select --app-name "My App"`                 |
 
 ### API Keys
 
@@ -119,6 +141,28 @@ Run `/algolia-cli:setup` to install the CLI and configure a profile, or follow [
 | Delete synonyms by ID | `algolia synonyms delete <index> --synonym-ids id1,id2 -y`     |
 | Save a single synonym | `algolia synonyms save <index> --id my-syn --synonyms foo,bar` |
 
+### Crawler
+
+| Task                          | Command                                                                 |
+|-------------------------------|-------------------------------------------------------------------------|
+| List crawlers                 | `algolia crawler list`                                                  |
+| List by app                   | `algolia crawler list --app-id <app-id>`                                |
+| Get crawler details           | `algolia crawler get <id>`                                              |
+| Get config only               | `algolia crawler get <id> --config-only`                                |
+| Create crawler                | `algolia crawler create <name> -F config.json`                          |
+| Start/resume crawler          | `algolia crawler run <id>`                                              |
+| Pause crawler(s)              | `algolia crawler pause <id> [<id2> ...]`                                |
+| Reindex crawler(s)            | `algolia crawler reindex <id> [<id2> ...]`                              |
+| Unblock crawler               | `algolia crawler unblock <id> -y`                                       |
+| Crawl specific URLs           | `algolia crawler crawl <id> --urls url1,url2`                           |
+| Test URL against crawler      | `algolia crawler test <id> --url <url>`                                 |
+| Test with config override     | `algolia crawler test <id> --url <url> -F config.json`                  |
+| Get crawl statistics          | `algolia crawler stats <id>`                                            |
+
+Most crawler commands support `--dry-run` to preview the request without sending it: `create`, `run`, `pause`, `reindex`, `unblock`, `test`.
+
+**Auth:** Crawler commands require `ALGOLIA_CRAWLER_USER_ID` and `ALGOLIA_CRAWLER_API_KEY` env vars, or `crawler_user_id`/`crawler_api_key` in the profile config file.
+
 ## Synonym Type Guide
 
 Choosing the right synonym type matters for search quality:
@@ -129,6 +173,14 @@ Choosing the right synonym type matters for search quality:
   Example: "TV" → "television", "flat screen" — searching "TV" finds "television" results, but searching "television" does NOT return "TV" results.
 
 **Rule of thumb:** If the user says "searching X should *also match* Y", that's one-way (`input: X`, `synonyms: [Y]`). If they say "X and Y should be equivalent/interchangeable", that's two-way.
+
+### Describe
+
+| Task                       | Command                          |
+|----------------------------|----------------------------------|
+| Describe root command tree | `algolia describe`               |
+| Describe a command         | `algolia describe search`        |
+| Describe a subcommand      | `algolia describe objects browse` |
 
 ## Key Conventions
 

--- a/skills/algolia-cli/evals/evals.json
+++ b/skills/algolia-cli/evals/evals.json
@@ -41,6 +41,30 @@
         "Uses 'algolia apikeys create' with --acl search and --indices blog_posts",
         "Does NOT use ndjson extension for settings (settings are regular JSON, not ndjson)"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "I just installed the Algolia CLI and need to authenticate. I'm on a remote server over SSH so I can't open a browser. After logging in, I want to make sure my credentials are saved as the default profile.",
+      "expected_output": "Commands to login without browser and verify default profile",
+      "files": [],
+      "expectations": [
+        "Uses 'algolia auth login --no-browser' since the user is on a remote server without browser access",
+        "Uses '--default' flag on the login command to save credentials as the default profile",
+        "Does NOT suggest 'algolia auth login' without --no-browser (would fail on SSH)",
+        "May suggest 'algolia profile list' to verify the profile was created correctly"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I want to see all my Algolia applications, then create a new one called 'Staging App' in the EU region. After that, switch to it so all future CLI commands use that app.",
+      "expected_output": "Commands to list applications, create a new one, and switch to it",
+      "files": [],
+      "expectations": [
+        "Uses 'algolia application list' to show existing applications",
+        "Uses 'algolia application create --name \"Staging App\" --region EU' to create the new app",
+        "Uses 'algolia application select --app-name \"Staging App\"' to switch to the new app",
+        "Does NOT use --region CA or other incorrect region values when the user specified EU"
+      ]
     }
   ]
 }

--- a/skills/algolia-cli/references/commands.md
+++ b/skills/algolia-cli/references/commands.md
@@ -4,6 +4,133 @@ Complete reference for agent-useful commands. All examples use non-interactive f
 
 ---
 
+## Auth
+
+### `algolia auth login`
+
+Sign in to your Algolia account via OAuth 2.0 with PKCE. Opens the browser for sign-in, starts a local callback server to receive the redirect automatically.
+
+```bash
+algolia auth login [flags]
+```
+
+| Flag             | Default | Description                                          |
+|------------------|---------|------------------------------------------------------|
+| `--app-name`     |         | Auto-select application by name (skips interactive)  |
+| `--profile-name` |         | Name for the CLI profile (defaults to app name)      |
+| `--default`      | `true`  | Set the profile as the default                       |
+| `--no-browser`   | `false` | Print the authorize URL instead of opening browser   |
+
+```bash
+# Sign in interactively (opens browser)
+algolia auth login
+
+# Auto-select an application by name
+algolia auth login --app-name "My App" --default
+
+# SSH / container: print URL, still waits for redirect
+algolia auth login --no-browser
+```
+
+After sign-in, the CLI fetches your applications, lets you pick one (or auto-selects via `--app-name`), and creates a CLI profile with the Admin API key.
+
+### `algolia auth logout`
+
+Sign out by revoking stored OAuth tokens on the server and removing them from the local keychain.
+
+```bash
+algolia auth logout
+```
+
+### `algolia auth signup`
+
+Create a new Algolia account via the browser. Opens the sign-up page, then completes the same OAuth flow as `login`.
+
+```bash
+algolia auth signup [flags]
+```
+
+| Flag             | Default | Description                                          |
+|------------------|---------|------------------------------------------------------|
+| `--app-name`     |         | Name for the first application                       |
+| `--profile-name` |         | Name for the CLI profile (defaults to app name)      |
+| `--default`      | `true`  | Set the profile as the default                       |
+| `--no-browser`   | `false` | Print the authorize URL instead of opening browser   |
+
+```bash
+# Create a new account (opens browser to sign-up page)
+algolia auth signup
+```
+
+---
+
+## Application Management
+
+### `algolia application list`
+
+List all Algolia applications associated with your account. Requires an active OAuth session (`algolia auth login`). Applications that already have a local CLI profile are marked.
+
+```bash
+algolia application list
+```
+
+Aliases: `ls`
+
+In interactive mode, offers to configure unconfigured applications as CLI profiles. Use `-o json` for machine-readable output.
+
+### `algolia application create`
+
+Create a new Algolia application and optionally configure it as a CLI profile. Requires an active OAuth session.
+
+```bash
+algolia application create [flags]
+```
+
+| Flag             | Default                  | Description                                     |
+|------------------|--------------------------|-------------------------------------------------|
+| `--name`         | `My First Application`   | Name for the application                        |
+| `--region`       |                          | Region code (e.g. `CA`, `US`, `EU`)             |
+| `--profile-name` |                          | Name for the CLI profile (defaults to app name) |
+| `--default`      | `false`                  | Set the new profile as the default              |
+| `--dry-run`      | `false`                  | Preview the create request without sending it   |
+
+```bash
+# Create with specific options
+algolia application create --name "My App" --region CA
+
+# Create and set as default profile
+algolia application create --name "My App" --region CA --default
+
+# Preview what would be created
+algolia application create --name "My App" --region CA --dry-run
+```
+
+### `algolia application select`
+
+Select an Algolia application to use as the default CLI profile. If the selected application already has a local profile, it is set as default. Otherwise, a new profile is created.
+
+```bash
+algolia application select [flags]
+```
+
+| Flag         | Default | Description                             |
+|--------------|---------|-----------------------------------------|
+| `--app-name` |         | Select application by name (non-interactive) |
+
+Aliases: `use`
+
+```bash
+# Select interactively
+algolia application select
+
+# Select by name (non-interactive)
+algolia application select --app-name "My App"
+```
+
+**Note:** `--app-name` is required in non-interactive mode.
+
+---
+
 ## Profile Management
 
 ### `algolia profile add`
@@ -702,6 +829,250 @@ algolia synonyms save MOVIES --id syn-3 --type placeholder --placeholder "<direc
 ```
 
 **Required ACL:** `editSettings`
+
+---
+
+## Crawler
+
+Crawler commands require separate authentication: set `ALGOLIA_CRAWLER_USER_ID` and `ALGOLIA_CRAWLER_API_KEY` environment variables, or add `crawler_user_id` and `crawler_api_key` to your profile config file (`~/.config/algolia/config.toml`).
+
+### `algolia crawler list`
+
+List crawlers, optionally filtered by name or application ID.
+
+```bash
+algolia crawler list [flags]
+```
+
+| Flag       | Default | Description       |
+|------------|---------|-------------------|
+| `--name`   |         | Filter by name    |
+| `--app-id` |         | Filter by app ID  |
+
+Aliases: `l`
+
+```bash
+# List all crawlers
+algolia crawler list
+
+# Filter by name
+algolia crawler list --name my-crawler
+
+# Filter by app ID
+algolia crawler list --app-id ABC123
+```
+
+Output columns: ID, NAME, STATUS, LAST REINDEX. Use `-o json` for machine-readable output.
+
+### `algolia crawler get`
+
+Get details of a specific crawler.
+
+```bash
+algolia crawler get <crawler_id> [flags]
+```
+
+| Flag            | Short | Default | Description                       |
+|-----------------|-------|---------|-----------------------------------|
+| `--config-only` | `-c`  | `false` | Display only the crawler config   |
+
+```bash
+# Get full crawler details
+algolia crawler get my-crawler
+
+# Get config only (useful for piping to create)
+algolia crawler get my-crawler --config-only
+```
+
+**Output format:** JSON.
+
+### `algolia crawler create`
+
+Create a new crawler from a configuration file.
+
+```bash
+algolia crawler create <name> -F <file> [flags]
+```
+
+| Flag        | Short | Default | Description                                        |
+|-------------|-------|---------|----------------------------------------------------|
+| `--file`    | `-F`  |         | Path to config file (`-` for stdin) — **required** |
+| `--dry-run` |       | `false` | Preview the create request without sending it      |
+
+Aliases: `new`, `n`, `c`
+
+```bash
+# Create from file
+algolia crawler create my-crawler -F config.json
+
+# Create from another crawler's config
+algolia crawler get other-crawler --config-only | algolia crawler create my-crawler -F -
+
+# Dry run
+algolia crawler create my-crawler -F config.json --dry-run
+```
+
+### `algolia crawler run`
+
+Start or resume a crawler. Previously ongoing crawls will be resumed; otherwise, the crawler waits for its next scheduled run.
+
+```bash
+algolia crawler run <crawler_id> [--dry-run]
+```
+
+| Flag        | Default | Description                                   |
+|-------------|---------|-----------------------------------------------|
+| `--dry-run` | `false` | Preview the run request without sending it    |
+
+```bash
+algolia crawler run my-crawler
+```
+
+### `algolia crawler pause`
+
+Pause one or more crawlers.
+
+```bash
+algolia crawler pause <crawler_id>... [--dry-run]
+```
+
+| Flag        | Default | Description                                     |
+|-------------|---------|-------------------------------------------------|
+| `--dry-run` | `false` | Preview the pause request without sending it    |
+
+```bash
+# Pause one
+algolia crawler pause my-crawler
+
+# Pause multiple
+algolia crawler pause my-crawler-1 my-crawler-2
+```
+
+### `algolia crawler reindex`
+
+Request the specified crawler(s) to start (or restart) crawling.
+
+```bash
+algolia crawler reindex <crawler_id>... [--dry-run]
+```
+
+| Flag        | Default | Description                                       |
+|-------------|---------|---------------------------------------------------|
+| `--dry-run` | `false` | Preview the reindex request without sending it    |
+
+```bash
+# Reindex one
+algolia crawler reindex my-crawler
+
+# Reindex multiple
+algolia crawler reindex my-crawler-1 my-crawler-2
+```
+
+### `algolia crawler unblock`
+
+Unblock a crawler by cancelling the task that is blocking it.
+
+```bash
+algolia crawler unblock <crawler_id> [-y] [--dry-run]
+```
+
+| Flag        | Short | Default | Description                                       |
+|-------------|-------|---------|---------------------------------------------------|
+| `--confirm` | `-y`  | `false` | Skip confirmation prompt                          |
+| `--dry-run` |       | `false` | Preview the unblock request without sending it    |
+
+```bash
+algolia crawler unblock my-crawler -y
+```
+
+### `algolia crawler crawl`
+
+Immediately crawl specific URLs. Records are pushed to the live index (or temporary index if a reindex is ongoing).
+
+```bash
+algolia crawler crawl <crawler_id> --urls <url>,... [flags]
+```
+
+| Flag     | Short | Default | Description                                          |
+|----------|-------|---------|------------------------------------------------------|
+| `--urls` | `-u`  |         | Comma-separated URLs (max 50) — **required**         |
+| `--save` | `-s`  | `false` | Save URLs to `extraUrls` in the crawler config       |
+
+```bash
+# Crawl specific URLs
+algolia crawler crawl my-crawler --urls https://example.com,https://example.com/page2
+
+# Crawl and save to config
+algolia crawler crawl my-crawler --urls https://example.com --save
+```
+
+### `algolia crawler test`
+
+Test a URL against the crawler's configuration and show the extracted records.
+
+```bash
+algolia crawler test <crawler_id> --url <url> [flags]
+```
+
+| Flag       | Short | Default | Description                                            |
+|------------|-------|---------|--------------------------------------------------------|
+| `--url`    | `-u`  |         | The URL to test — **required**                         |
+| `--config` | `-F`  |         | Config file to override the crawler's config (`-` for stdin) |
+| `--dry-run`|       | `false` | Preview the test request without sending it            |
+
+```bash
+# Test a URL
+algolia crawler test my-crawler --url https://example.com
+
+# Test with config override
+algolia crawler test my-crawler --url https://example.com -F config.json
+
+# Dry run
+algolia crawler test my-crawler --url https://example.com --dry-run
+```
+
+**Output format:** JSON.
+
+### `algolia crawler stats`
+
+Get a summary of crawled URL statuses for a crawler.
+
+```bash
+algolia crawler stats <crawler_id>
+```
+
+```bash
+algolia crawler stats my-crawler
+```
+
+Output columns: STATUS, CATEGORY, REASON, COUNT. Use `-o json` for machine-readable output.
+
+---
+
+## Describe
+
+### `algolia describe`
+
+Describe the CLI's command tree in a machine-readable JSON format. Useful for agents and automation to discover available commands and flags.
+
+```bash
+algolia describe [command] [subcommand]...
+```
+
+Aliases: `schema`
+
+```bash
+# Describe the root command (lists all top-level commands)
+algolia describe
+
+# Describe a specific command
+algolia describe search
+
+# Describe a subcommand
+algolia describe objects browse
+```
+
+**Output format:** JSON with `schemaVersion` and `command` fields.
 
 ---
 


### PR DESCRIPTION
## What does this skill do?

Adds the following commands, available on CLI v1.8.0:
- Auth
- Application
- Crawler
- Describe

## Checklist

- [x] `python3 scripts/validate_skills.py .` passes (0 errors)
- [x] Skill description is under 1024 chars and includes WHEN and WHEN NOT to trigger
- [x] `evals/evals.json` exists with at least 1 realistic prompt
- [x] Skill is self-contained — no `../other-skill/` references
- [x] Registered in `.claude-plugin/marketplace.json` (new skills only)
- [x] Goes in `skills/` here if useful to customers; internal-only skills → `algolia/internal-skills`
