### PR TITLE
fix(instantsearch): reset panel body top position

### DIFF
--- a/skills/instantsearch/references/react/autocomplete/styling.md
+++ b/skills/instantsearch/references/react/autocomplete/styling.md
@@ -61,6 +61,7 @@ body.ais-Autocomplete--detached {
   flex-grow: 1;
   position: relative;
   overflow: hidden;
+  top: 0;
 }
 
 /* 6. Inner panel layout scrolls within the flex-grown space */


### PR DESCRIPTION
## Summary

Adds `top: 0` to the `.ais-AutocompleteDetachedContainer .ais-AutocompletePanel` rule in the autocomplete styling reference to explicitly reset the panel body's top position on mobile.