### PR TITLE
fix(algobot-cli): doc corrections

### DIFF
--- a/skills/algobot-cli/SKILL.md
+++ b/skills/algobot-cli/SKILL.md
@@ -145,6 +145,8 @@ algobot agents watch patch.json             # Auto-apply patches on file change
 - **Auth stored in `~/.algobot-cookie`** (AES-256-GCM). Inspect with `algobot auth show`.
 - **`--config` auto-discovers `agent-config.json`** in cwd. Explicit: `--config path/to/config.json`.
 - **algobot = dev/deploy tool; REST API = production invocation.** Use algobot to build and publish agents; call the Agent Studio completions API directly from your app. Don't guess the endpoint URL — run `algobot agents get <id>` to retrieve it, or check the Agent Studio dashboard.
+- **Completions URL has no `/agent-studio` prefix.** Use `agent-studio.<region>.algolia.com/1/agents/<id>/completions?stream=false&compatibilityMode=ai-sdk-4`. `compatibilityMode` is required (omitting → 422). Response: `{ id, role, content }` with `content` as a flat string.
+- **`agents create --provider <name>` does not link the provider.** Agent stays `draft`, publish 409s. After create, run `algobot agents patch <id> --json patch.json` with `{"providerId": "<uuid>"}`, then publish.
 
 ## Reference Docs
 

--- a/skills/algobot-cli/references/commands.md
+++ b/skills/algobot-cli/references/commands.md
@@ -7,7 +7,7 @@ algobot agents list [--jq '<expr>']
 algobot agents get <agent-id>
 algobot agents create --name <name> --model <model> [--config <file>] [--var k=v]
 algobot agents update <agent-id> [--name <name>] [--model <model>] [--config <file>] [--var k=v] [--publish]
-algobot agents patch <agent-id> --file <json-file>
+algobot agents patch <agent-id> --json <file>
 algobot agents delete <agent-id>
 algobot agents publish <agent-id>
 algobot agents unpublish <agent-id>
@@ -42,7 +42,7 @@ algobot profiles remove <name>
 algobot providers list
 algobot providers get <provider-id>
 algobot providers create --name <name>
-algobot providers patch <provider-id> --file <json-file>
+algobot providers patch <provider-id> --json <file>
 algobot providers delete <provider-id>
 ```
 

--- a/skills/algobot-cli/references/config-as-code.md
+++ b/skills/algobot-cli/references/config-as-code.md
@@ -27,14 +27,26 @@ Produces `agent-config.json` with the agent's current config, and `PROMPT.md` if
   "name": "{{event_name}} Support Bot",
   "model": "gpt-4o",
   "instructions": "PROMPT.md",
-  "tools": [...],
-  "indexName": "{{index_name}}"
+  "tools": [
+    {
+      "type": "algolia_search_index",
+      "name": "search_products",
+      "indices": [
+        {
+          "index": "{{index_name}}",
+          "description": "Product catalog. Search by title, brand, or category."
+        }
+      ]
+    }
+  ]
 }
 ```
 
-- `"instructions": "PROMPT.md"` — loads instructions from the referenced `.md` file
-- `{{key}}` — mustache placeholder, resolved via `--var key=value`
+- `"instructions": "PROMPT.md"` — loads instructions from the referenced `.md` file.
+- `{{key}}` — mustache placeholder, resolved via `--var key=value`.
 - JSON config fields: JSON-safe escaping. Instructions (`.md`): raw substitution.
+
+> Top-level `indexName` is silently stripped — index names belong in `tools[].indices[].index`.
 
 ## Template Variables
 


### PR DESCRIPTION
## What does this skill do?

Three documentation corrections to the existing `algobot-cli` skill. **no new skill**, no behavior change. Verified against `algobot@2.0.0` (latest published on npm) and the running production Agent Studio API.

### What's wrong today

| File | Fix |
|---|---|
| `references/commands.md` | `agents patch` / `providers patch` flag is `--json`, not `--file`. |
| `references/config-as-code.md` | `agent-config.json` example was stale: uses a top-level `indexName` (silently stripped on submit) and a placeholder `tools: [...]`. New shape: each tool needs `name` + `indices: [{index, description}]` for `algolia_search_index`. |
| `SKILL.md` (Gotchas) | Two failure modes look like *"agent not found"* but aren't: completions URL has no `/agent-studio` prefix and requires `compatibilityMode`; `agents create --provider <name>` doesn't actually link the provider; needs an `agents patch --json '{providerId: <uuid>}'` step between create and publish. |

## Checklist

- [x] \`python3 scripts/validate_skills.py .\` passes (0 errors)
- [ ] ~Skill description is under 1024 chars and includes WHEN and WHEN NOT to trigger~ — N/A, no description change
- [ ] ~\`evals/evals.json\` exists with at least 1 realistic prompt~ — N/A, docs-only
- [x] Skill is self-contained — no \`../other-skill/\` references
- [ ] ~Registered in \`.claude-plugin/marketplace.json\` (new skills only)~ — N/A, existing skill
- [x] Goes in \`skills/\` here if useful to customers; internal-only skills → \`algolia/internal-skills\`