### PR TITLE
feat(algolia-crawler): add crawler skill for RAG-optimized indexing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,6 +44,15 @@
       "skills": [
         "./skills/instantsearch"
       ]
+    },
+    {
+      "name": "algolia-crawler",
+      "description": "Crawl and index web pages into Algolia for RAG using the Algolia CLI. Use when a user wants to set up the Algolia Crawler, index a website/docs/specific pages for RAG or an AI agent's knowledge base, write or debug a crawler recordExtractor, or handle JavaScript-rendered pages that won't index. Guides ingestion end-to-end with `algolia crawler` commands: inspect the page, write a RAG-optimized recordExtractor, validate with `algolia crawler test` before indexing, apply index settings explicitly, then reindex. Do NOT use for building the chatbot/agent layer itself (use algobot-cli), raw record/synonym/settings ops on an existing index (use algolia-cli), frontend search UI (use instantsearch), or read-only search/analytics (use algolia-mcp).",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/algolia-crawler"
+      ]
     }
   ]
 }

--- a/skills/algolia-crawler/SKILL.md
+++ b/skills/algolia-crawler/SKILL.md
@@ -88,7 +88,7 @@ algolia crawler stats  <id>                        # crawl status summary
 Two CLI realities to plan around (details in [cli.md](references/cli.md#gotchas)):
 
 - **Set `renderJavaScript: true` (boolean).** The CLI only accepts the boolean form; the object form (`{ enabled, patterns, waitTime }`) makes `get`/`list`/`create -F` fail to parse. Boolean `true` uses the default render wait, which is enough for most pages — confirm with `crawler test` (empty values mean the page needs more render time).
-- **`create` prints nothing and there's no config-update or delete command.** After `create`, recover the id with `algolia crawler get <name>` or `algolia crawler list`. To change a config, re-create; to delete, use the Algolia dashboard.
+- **`create` prints nothing and there's no config-update or delete command.** After `create`, recover the id from `algolia crawler list` (`get` needs a UUID — it doesn't accept a name). If `list` errors because another crawler in the account uses a non-boolean `renderJavaScript`, there's no pure-CLI recovery — look the id up via the Crawler REST list endpoint (`GET /1/crawlers?name=<name>`). To change a config, re-create; to delete, use the dashboard or REST `DELETE`.
 
 ## References
 

--- a/skills/algolia-crawler/SKILL.md
+++ b/skills/algolia-crawler/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: algolia-crawler
+description: >-
+  Use this skill whenever a user wants to crawl one or more web pages or a
+  whole site and turn them into an Algolia index using the Algolia CLI —
+  especially for RAG, AI search, semantic search, or Agent Studio retrieval.
+  Triggers: "index my website/docs with Algolia", "set up the Algolia Crawler",
+  "crawl this page for RAG", "scrape my site into Algolia", "build a knowledge
+  base for my AI agent from these URLs", writing or debugging a crawler
+  recordExtractor, or handling JavaScript-rendered pages that won't index. It
+  guides ingestion end-to-end with `algolia crawler` commands: inspect the
+  page, write a RAG-optimized recordExtractor, validate with `algolia crawler
+  test` BEFORE indexing, apply index settings explicitly, then reindex. Do NOT
+  use for building the chatbot/agent layer itself (use algobot-cli), raw
+  record/synonym/settings ops on an existing index (use algolia-cli), frontend
+  search UI (use instantsearch), or read-only search/analytics (use
+  algolia-mcp).
+license: MIT
+metadata:
+  author: algolia
+  version: "1.0"
+---
+
+# Algolia Crawler
+
+Turn web pages into a **RAG-optimized Algolia index** with the [Algolia Crawler](https://www.algolia.com/doc/tools/crawler/getting-started/overview), driven entirely by the **Algolia CLI** (`algolia crawler …`). The Crawler visits URLs, extracts content with a JavaScript `recordExtractor`, and writes Algolia records on a schedule — no scraping code to maintain.
+
+The single most important idea: **crawling for RAG is not the same as crawling for site search.** A RAG record is a chunk of text that will be dropped into an LLM's context window *in isolation*. That changes how you shape every record (see [The RAG record mental model](#the-rag-record-mental-model)).
+
+## When to use this skill vs. the others
+
+| Need | Skill |
+|------|-------|
+| Crawl/ingest web pages into an index (this workflow) | **algolia-crawler** |
+| Build the chatbot / agent / RAG app on top of the index | **algobot-cli** |
+| Raw record/settings/synonym/rule ops on an existing index | **algolia-cli** |
+| Read-only search, analytics, recommendations | **algolia-mcp** |
+| Frontend search UI (autocomplete, results, facets) | **instantsearch** |
+
+**Rule of thumb:** if the user wants to *get web content into Algolia*, you're in the right skill. Once the index exists and they want to *ask questions over it*, hand off to **algobot-cli**.
+
+## The RAG record mental model
+
+Each record is retrieved and shown to an LLM alone, without the surrounding page. So optimize for that:
+
+1. **Small and single-topic.** One idea, one fact, one Q&A per record — not a whole page. Granular records retrieve precisely and waste less of the context window.
+2. **Self-contained.** Every record carries the context needed to stand alone: the entity it's about, the page title, the section heading. The LLM won't see the rest of the page.
+3. **Natural-language `content`, even for structured data.** This is the highest-leverage move. Don't store only `{model: "X", score: 0.87}` — also synthesize a sentence: *"Model X scores 0.87 on relevance…"*. Both keyword and vector retrieval, and the LLM itself, want prose.
+4. **Structured attributes for filtering.** Alongside `content`, keep clean fields (`category`, `type`, `date`, numeric values) so retrieval can be scoped with `filters` and facets.
+
+If you internalize only one thing from this skill, make it this list. Everything else is mechanics.
+
+## The workflow
+
+Follow these steps in order. Full commands, config, and code live in the references — read them as you reach each step.
+
+1. **Set up the CLI and credentials.** Install the CLI and export your Crawler credentials (a Crawler *user ID* + *API key*, distinct from your app keys), plus an Algolia **write** API key for the target index and your **App ID**. See [cli.md](references/cli.md#setup-and-credentials).
+2. **Inspect the page first — is it JavaScript-rendered?** Many modern pages load their real content via XHR after load, so a naive crawl indexes empty shells. Detect this and enable rendering. See [javascript-rendering.md](references/javascript-rendering.md).
+3. **Write a `recordExtractor` that emits RAG records** following the mental model above — one record per unit, a prose `content` field, structured attributes, and chunking for long prose. See [record-extractor.md](references/record-extractor.md).
+4. **Validate with `algolia crawler test` BEFORE indexing.** It runs your config against a live URL and returns the records it *would* create, without writing anything. Use it as your feedback loop — and as a DOM inspector to fix selectors against the real rendered markup. See [workflow.md](references/workflow.md#validate-before-you-index).
+5. **Apply index settings explicitly.** Do not rely on `initialIndexSettings` to configure the index — in practice it frequently does not apply. Set `searchableAttributes`, `attributesForFaceting`, etc. yourself with `algolia settings import` after the first crawl. See [rag-index-settings.md](references/rag-index-settings.md).
+6. **Reindex, then verify** by searching the index (`algolia search`) for a few realistic RAG questions before trusting it.
+7. **Schedule** a recurring crawl so the index stays fresh as the source pages change.
+
+The complete, copy-adaptable end-to-end run (create → test → settings → reindex → verify) is in [workflow.md](references/workflow.md).
+
+## Two things that will bite you
+
+These are the non-obvious failures. Both references cover them, but they're worth stating up front:
+
+- **JavaScript-rendered data.** If the page shows `Loading…` placeholders in its initial HTML, or the numbers/table appear only after load, you must enable `renderJavaScript`. A crawl without it indexes nothing useful. ([javascript-rendering.md](references/javascript-rendering.md))
+- **Values hidden in attributes.** Rendered pages often keep the real value in an attribute (e.g. `data-tip="Score: 79.8%"`) while the visible cell shows only a bar or a delta. Extract from the attribute, not the visible text. ([record-extractor.md](references/record-extractor.md#reading-values-from-attributes))
+
+## Driving it with the CLI
+
+Everything runs through `algolia crawler …` (and `algolia settings` / `algolia search` for the index side). Full cheatsheet and the gotchas below are in [cli.md](references/cli.md).
+
+```bash
+algolia crawler create <name> -F config.json     # create (prints nothing on success)
+algolia crawler test   <id> --url <url> [-F cfg] # extract records WITHOUT indexing
+algolia crawler reindex <id>                      # start a crawl that writes records
+algolia crawler get    <id>                        # inspect crawler + config/status
+algolia crawler stats  <id>                        # crawl status summary
+```
+
+Two CLI realities to plan around (details in [cli.md](references/cli.md#gotchas)):
+
+- **Set `renderJavaScript: true` (boolean).** The CLI only accepts the boolean form; the object form (`{ enabled, patterns, waitTime }`) makes `get`/`list`/`create -F` fail to parse. Boolean `true` uses the default render wait, which is enough for most pages — confirm with `crawler test` (empty values mean the page needs more render time).
+- **`create` prints nothing and there's no config-update or delete command.** After `create`, recover the id with `algolia crawler get <name>` or `algolia crawler list`. To change a config, re-create; to delete, use the Algolia dashboard.
+
+## References
+
+- [workflow.md](references/workflow.md) — the full end-to-end CLI run: config, test-before-index loop, settings, reindex, verify, schedule.
+- [record-extractor.md](references/record-extractor.md) — RAG record patterns, helpers, reading values from attributes, chunking long prose.
+- [rag-index-settings.md](references/rag-index-settings.md) — index settings tuned for retrieval, NeuralSearch/vector, query-time filtering for RAG.
+- [javascript-rendering.md](references/javascript-rendering.md) — detecting and handling JavaScript-rendered pages.
+- [cli.md](references/cli.md) — setup, credentials, the `algolia crawler` command cheatsheet, and the CLI gotchas in detail.

--- a/skills/algolia-crawler/SKILL.md
+++ b/skills/algolia-crawler/SKILL.md
@@ -62,6 +62,8 @@ Follow these steps in order. Full commands, config, and code live in the referen
 6. **Reindex, then verify** by searching the index (`algolia search`) for a few realistic RAG questions before trusting it.
 7. **Schedule** a recurring crawl so the index stays fresh as the source pages change.
 
+**Crawling a whole site or section (one URL → all its sub-pages)?** The crawler discovers sub-pages via `startUrls`/`sitemaps`/`discoveryPatterns` — but the config must be shaped from *all* the page types it will hit, not just the start page. A config fitted to the landing page produces junk on the article/reference/blog templates it never saw. Discover the URL set, group it into templates, sample a representative page per template, and validate the extractor against **each**. See [site-crawls.md](references/site-crawls.md).
+
 The complete, copy-adaptable end-to-end run (create → test → settings → reindex → verify) is in [workflow.md](references/workflow.md).
 
 ## Two things that will bite you
@@ -91,6 +93,7 @@ Two CLI realities to plan around (details in [cli.md](references/cli.md#gotchas)
 ## References
 
 - [workflow.md](references/workflow.md) — the full end-to-end CLI run: config, test-before-index loop, settings, reindex, verify, schedule.
+- [site-crawls.md](references/site-crawls.md) — crawling a whole site/section: discover sub-pages, group page templates, sample and validate each, cover them with a branching extractor or multiple actions.
 - [record-extractor.md](references/record-extractor.md) — RAG record patterns, helpers, reading values from attributes, chunking long prose.
 - [rag-index-settings.md](references/rag-index-settings.md) — index settings tuned for retrieval, NeuralSearch/vector, query-time filtering for RAG.
 - [javascript-rendering.md](references/javascript-rendering.md) — detecting and handling JavaScript-rendered pages.

--- a/skills/algolia-crawler/evals/EVAL_RESULTS.md
+++ b/skills/algolia-crawler/evals/EVAL_RESULTS.md
@@ -4,14 +4,15 @@ Evaluation performed on 2026-07-02 using Claude Opus 4.8 (1M context).
 
 ## Summary
 
-The skill was evaluated across 3 realistic user scenarios, comparing **with-skill** (Claude reads the skill before responding) vs **without-skill** (Claude relies on general knowledge). Each output was graded against the assertions in [`evals.json`](evals.json).
+The skill was evaluated across 4 realistic user scenarios, comparing **with-skill** (Claude reads the skill before responding) vs **without-skill** (Claude relies on general knowledge). Each output was graded against the assertions in [`evals.json`](evals.json).
 
 | Metric | Without Skill | With Skill |
 |--------|:------------:|:----------:|
 | **Eval 1** — JS-rendered pricing page → support agent | 57% (4/7) | **100% (7/7)** |
 | **Eval 2** — Debug a broken recordExtractor | 75% (3/4) | **100% (4/4)** |
 | **Eval 3** — Index a docs site for RAG | 80% (4/5) | **100% (5/5)** |
-| **Average pass rate** | **~71%** | **100%** |
+| **Eval 4** — Whole-site crawl across page templates | 83% (5/6) | **100% (6/6)** |
+| **Average pass rate** | **~74%** | **100%** |
 
 Cost of the skill: with-skill runs used ~40% more tokens on average (~48.6k vs ~34.6k) — the cost of reading SKILL.md and its references.
 
@@ -25,6 +26,7 @@ The skill's value concentrates on **CLI-specific correctness and non-obvious got
 - **Validate before indexing with `algolia crawler test`.** Baselines relied on the dashboard URL Tester or skipped validation; the skill makes the test-before-reindex loop (and using it as a DOM inspector) central.
 - **Apply index settings explicitly.** Baselines relied on `initialIndexSettings` (Eval 1) or omitted settings application entirely (Eval 3, which missed this assertion) — the exact trap that leaves facets/filters silently broken. The skill mandates `algolia settings import` after the first crawl.
 - **Staying CLI-only.** Baselines drifted to the dashboard/REST; the skill keeps the whole workflow in `algolia crawler …`.
+- **Validating across page templates.** On a whole-site crawl (Eval 4), the baseline configured sub-page discovery and even proposed multiple actions, but never validated the extractor against a representative page *per template* — so a config fitted to the homepage would silently misfire on other page types. The skill's `site-crawls.md` makes "discover → group templates → sample and `crawler test` each" explicit.
 
 ## Eval details
 
@@ -36,6 +38,9 @@ This is where the skill's marginal value is smallest: debugging "empty field / m
 
 ### Eval 3 — Index a docs site for RAG
 Baseline was strong on chunking and semantic retrieval. It missed applying index settings explicitly (relied on defaults / `initialIndexSettings`). The with-skill run scoped the crawl, chunked per section, and applied settings with `algolia settings import`.
+
+### Eval 4 — Whole-site crawl across page templates
+Given only a root URL, both runs configured autonomous sub-page discovery and acknowledged multiple page types, and both proposed a branching extractor / multiple actions. Only the with-skill run **validated the extractor against a representative page per template** (`crawler test` on more than one URL) and stayed CLI-only end to end — the baseline configured coverage but never sampled/tested across templates, the exact step that keeps a site-wide config from being overfit to the start page.
 
 ## Method
 

--- a/skills/algolia-crawler/evals/EVAL_RESULTS.md
+++ b/skills/algolia-crawler/evals/EVAL_RESULTS.md
@@ -42,6 +42,10 @@ Baseline was strong on chunking and semantic retrieval. It missed applying index
 ### Eval 4 — Whole-site crawl across page templates
 Given only a root URL, both runs configured autonomous sub-page discovery and acknowledged multiple page types, and both proposed a branching extractor / multiple actions. Only the with-skill run **validated the extractor against a representative page per template** (`crawler test` on more than one URL) and stayed CLI-only end to end — the baseline configured coverage but never sampled/tested across templates, the exact step that keeps a site-wide config from being overfit to the start page.
 
+## Real-world validation
+
+Beyond the eval prompts, the skill was run end-to-end to actually index the Algolia Agent Studio docs (`https://www.algolia.com/doc/guides/algolia-ai/agent-studio` and its `how-to/` sub-pages) — 13 pages, 130 self-contained `doc_section` records, verified with real queries. The run confirmed the JS-rendering and query-time-matching guidance, and surfaced one correction now folded in: `algolia crawler get` accepts a **UUID only** (not a crawler name), so id recovery after `create` uses `crawler list`, with a REST `?name=` fallback for when `list` is broken by a non-boolean `renderJavaScript` crawler elsewhere in the account.
+
 ## Method
 
 For each scenario, two subagents ran the same prompt — one with the skill available, one without — and produced an advisory answer with concrete commands/config (no live Algolia credentials were used). Outputs were graded against the per-eval `expectations` in `evals.json`.

--- a/skills/algolia-crawler/evals/EVAL_RESULTS.md
+++ b/skills/algolia-crawler/evals/EVAL_RESULTS.md
@@ -1,0 +1,42 @@
+# Algolia Crawler Skill — Evaluation Results
+
+Evaluation performed on 2026-07-02 using Claude Opus 4.8 (1M context).
+
+## Summary
+
+The skill was evaluated across 3 realistic user scenarios, comparing **with-skill** (Claude reads the skill before responding) vs **without-skill** (Claude relies on general knowledge). Each output was graded against the assertions in [`evals.json`](evals.json).
+
+| Metric | Without Skill | With Skill |
+|--------|:------------:|:----------:|
+| **Eval 1** — JS-rendered pricing page → support agent | 57% (4/7) | **100% (7/7)** |
+| **Eval 2** — Debug a broken recordExtractor | 75% (3/4) | **100% (4/4)** |
+| **Eval 3** — Index a docs site for RAG | 80% (4/5) | **100% (5/5)** |
+| **Average pass rate** | **~71%** | **100%** |
+
+Cost of the skill: with-skill runs used ~40% more tokens on average (~48.6k vs ~34.6k) — the cost of reading SKILL.md and its references.
+
+## Where the skill makes the difference
+
+A capable model already handles the *generic* RAG shaping well without the skill — one record per retrieval unit, natural-language `content`, chunking long prose, recommending semantic/NeuralSearch. The docs scenario (Eval 3) baseline was strong here, as this is well-documented DocSearch territory.
+
+The skill's value concentrates on **CLI-specific correctness and non-obvious gotchas** that the baseline consistently got wrong:
+
+- **Boolean `renderJavaScript`.** Baselines reached for the documented object form (`{ enabled, patterns, waitTime }`), which breaks `crawler get`/`list`/`create -F` in the CLI. The skill steers to `renderJavaScript: true`.
+- **Validate before indexing with `algolia crawler test`.** Baselines relied on the dashboard URL Tester or skipped validation; the skill makes the test-before-reindex loop (and using it as a DOM inspector) central.
+- **Apply index settings explicitly.** Baselines relied on `initialIndexSettings` (Eval 1) or omitted settings application entirely (Eval 3, which missed this assertion) — the exact trap that leaves facets/filters silently broken. The skill mandates `algolia settings import` after the first crawl.
+- **Staying CLI-only.** Baselines drifted to the dashboard/REST; the skill keeps the whole workflow in `algolia crawler …`.
+
+## Eval details
+
+### Eval 1 — JS-rendered pricing page for a support agent
+Both runs correctly identified the page as JS-rendered, emitted feature- and plan-level records with natural-language content, and kept structured attributes. Only the with-skill run used the boolean render form, validated with `algolia crawler test`, applied settings explicitly with `algolia settings import`, and stayed CLI-only. The baseline used the object render form + `initialIndexSettings` and steered to the dashboard.
+
+### Eval 2 — Debug a broken recordExtractor
+This is where the skill's marginal value is smallest: debugging "empty field / mashed text" is something a strong model reasons about well (read the value from an attribute, inspect the rendered DOM, target a specific child). The skill added the `algolia crawler test` DOM-dump loop and the `.eq(i)` extraction pattern explicitly.
+
+### Eval 3 — Index a docs site for RAG
+Baseline was strong on chunking and semantic retrieval. It missed applying index settings explicitly (relied on defaults / `initialIndexSettings`). The with-skill run scoped the crawl, chunked per section, and applied settings with `algolia settings import`.
+
+## Method
+
+For each scenario, two subagents ran the same prompt — one with the skill available, one without — and produced an advisory answer with concrete commands/config (no live Algolia credentials were used). Outputs were graded against the per-eval `expectations` in `evals.json`.

--- a/skills/algolia-crawler/evals/evals.json
+++ b/skills/algolia-crawler/evals/evals.json
@@ -40,6 +40,20 @@
         "Recommends enabling semantic retrieval / NeuralSearch (or vectors) for natural-language questions",
         "Scopes the crawl (discoveryPatterns / pathsToMatch / maxUrls) to the docs section"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "We just launched our help center at https://help.acme.com and I want our AI assistant to answer from all of it. I'll only give you the root URL — the crawler should index every page under it on its own, and the setup needs to work across all the different page types (getting-started guides, API reference, release notes), not just the homepage. How do I set this up?",
+      "expected_output": "Configure autonomous sub-page discovery, identify the distinct page templates, validate the extractor against a representative page per template, cover them with a branching extractor or multiple actions, apply unified settings, and verify retrieval across page types — all via the CLI.",
+      "files": [],
+      "expectations": [
+        "Configures autonomous sub-page discovery from the single root URL (startUrls + discoveryPatterns, sitemaps if available, raised maxDepth/maxUrls) rather than a single-page crawl",
+        "Recognizes the site has multiple page templates/types and that the config must work across ALL of them, not just the start/home page",
+        "Validates against a representative page from EACH template with `algolia crawler test` (tests more than one URL), not just the homepage",
+        "Covers heterogeneous templates via a branching recordExtractor (by URL/DOM) or multiple actions with per-template pathsToMatch",
+        "Applies unified index settings across templates with `algolia settings import` and verifies retrieval with queries spanning different page types",
+        "Uses the Algolia CLI (algolia crawler ...) throughout"
+      ]
     }
   ]
 }

--- a/skills/algolia-crawler/evals/evals.json
+++ b/skills/algolia-crawler/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "algolia-crawler",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We have a pricing/comparison page at https://acme.example.com/plans that shows a table of plans and their features — but the table data loads after the page renders (I see 'Loading…' in the raw HTML). I want to get this into Algolia so our support AI agent can answer questions like 'which plan includes SSO'. How do I set up the crawler so it's actually good for that?",
+      "expected_output": "A plan to crawl the JS-rendered page with renderJavaScript enabled, a recordExtractor producing one RAG record per plan with a natural-language content field plus structured attributes, validation via the test endpoint before indexing, and explicit index settings.",
+      "files": [],
+      "expectations": [
+        "Identifies the page as JavaScript-rendered and enables renderJavaScript (boolean true or object form)",
+        "Proposes one record per plan (retrieval unit) rather than one record per page",
+        "Includes a natural-language 'content' field synthesized from the plan's fields, plus structured attributes for filtering",
+        "Uses `algolia crawler test` to validate extraction BEFORE running a full reindex (algolia crawler reindex)",
+        "Applies index settings explicitly with `algolia settings import` rather than relying only on initialIndexSettings",
+        "Uses the Algolia CLI (algolia crawler ...) rather than the Crawler REST API / curl",
+        "Does NOT build the chatbot/agent itself, or defers that to Agent Studio / algobot-cli"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "My crawler runs but the records are junk — the 'price' field comes back empty and the product name is a mashed-together string. The page is at https://shop.example.com/catalog and the prices seem to render as little bars, not text. Help me fix the recordExtractor.",
+      "expected_output": "Guidance to inspect the real rendered DOM via the test endpoint, read the value from an attribute rather than visible text, and iterate selectors.",
+      "files": [],
+      "expectations": [
+        "Suggests using the crawler test endpoint to dump/inspect the real rendered markup (e.g. returning element .html() or attributes) to debug selectors",
+        "Recognizes the value is likely stored in an attribute (e.g. data-*) and extracts from the attribute rather than the visible cell text",
+        "Recommends targeting specific child selectors / using .eq(i) instead of grabbing a whole cell's concatenated text",
+        "Frames it as an iterate-against-test-output loop rather than guessing selectors blindly"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I want to index our documentation site (https://docs.example.com, a few hundred pages) into Algolia to power a RAG assistant. What's the best way to structure the index and crawl so retrieval is high quality?",
+      "expected_output": "A crawl scoped to the docs, records chunked per section/heading (small, self-contained), natural-language content, RAG-tuned index settings including a recommendation to enable NeuralSearch/semantic search, and explicit settings application.",
+      "files": [],
+      "expectations": [
+        "Chunks content into small, self-contained records (per section/heading or via splitContentIntoRecords / docsearch helper) rather than one record per page",
+        "Emphasizes self-contained records that carry section/page context so they make sense in isolation",
+        "Recommends RAG-tuned index settings (content as a primary searchable attribute; facets/filters) applied explicitly",
+        "Recommends enabling semantic retrieval / NeuralSearch (or vectors) for natural-language questions",
+        "Scopes the crawl (discoveryPatterns / pathsToMatch / maxUrls) to the docs section"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-crawler/references/cli.md
+++ b/skills/algolia-crawler/references/cli.md
@@ -1,0 +1,68 @@
+# Algolia CLI reference (Crawler)
+
+Everything in this skill runs through the **Algolia CLI**. Read the [gotchas](#gotchas) — a couple of them will save you an afternoon.
+
+Install: `brew install algolia/algolia-cli/algolia` (or see the CLI docs for other platforms). For deeper CLI usage on the index side (records, synonyms, rules), see the **algolia-cli** skill.
+
+## Setup and credentials
+
+Two distinct sets of credentials are involved — they're commonly confused:
+
+1. **Crawler API credentials** — a Crawler **user ID** + **API key**, found in the Crawler dashboard under Settings → API credentials. These authenticate the `algolia crawler` commands. They are **not** your app's search/admin keys.
+2. **An Algolia write API key** for the target app — embedded in the crawler config (`apiKey`) so the crawler can write records. Prefer a **restricted key** scoped to the index pattern with ACLs: `addObject, deleteObject, deleteIndex, editSettings, settings, listIndexes, browse, search`. Plus your **App ID** (public).
+
+The `algolia crawler` commands read the Crawler credentials from these exact environment variables:
+
+```bash
+export ALGOLIA_CRAWLER_USER_ID="…"     # Crawler user ID
+export ALGOLIA_CRAWLER_API_KEY="…"     # Crawler API key
+export APP_ID="…"                       # Algolia App ID (public)
+export WRITE_KEY="…"                    # restricted write key for the index
+```
+
+You can also store them in a profile at `~/.config/algolia/config.toml` (`crawler_user_id` / `crawler_api_key`). Never paste secret keys into chats, tickets, or committed files. If a key is exposed, rotate it.
+
+## Command cheatsheet
+
+```bash
+# --- crawler lifecycle ---
+algolia crawler create <name> -F config.json     # create (prints nothing on success)
+algolia crawler list                              # list crawlers (find an id)
+algolia crawler get <id|name>                     # inspect crawler + config + status
+algolia crawler test <id> --url <url> [-F cfg]    # extract records WITHOUT indexing
+algolia crawler reindex <id>                      # start a crawl that writes records
+algolia crawler run <id> | pause <id>             # resume / pause
+algolia crawler stats <id>                        # crawl status summary
+algolia crawler crawl <id> --url <url>            # crawl specific URL(s)
+algolia crawler unblock <id>                      # clear a blocked crawler
+
+# --- index side (same CLI) ---
+algolia settings import <index> --application-id $APP_ID --api-key $WRITE_KEY -F settings.json --wait
+algolia settings get <index> --application-id $APP_ID --api-key $WRITE_KEY
+algolia search <index> --application-id $APP_ID --api-key $SEARCH_KEY --query "…" --hitsPerPage 3
+```
+
+The `recordExtractor` inside `config.json` is stored as `{"__type": "function", "source": "<stringified function>"}`. Build configs with `jq --rawfile` so the function's quotes/newlines are escaped correctly (see [workflow.md](workflow.md#2-write-the-config)).
+
+## Gotchas
+
+### The `renderJavaScript` gotcha
+The CLI models `renderJavaScript` as a **boolean only**. If your config uses the documented object form (`{ "enabled": true, "patterns": [...], "waitTime": {...} }`) or the array (patterns) form, the CLI fails to deserialize it:
+
+```
+json: cannot unmarshal object into Go struct field Config.config.renderJavaScript of type bool
+```
+
+This breaks `crawler get`, `crawler list`, and `crawler create -F` for that config. So:
+
+- **Use `renderJavaScript: true`.** In practice the default render wait is enough for most pages — validate with `crawler test` (empty field/score values mean the page needs more render time).
+- `crawler list` fails account-wide if *any* crawler in the app uses a non-boolean `renderJavaScript` — even one you didn't create. If `list` errors with the message above, use `crawler get <name>` to work with your specific crawler.
+
+### `create` prints nothing on success
+`algolia crawler create` returns silently — it does not echo the new crawler id. Recover it right after with `algolia crawler get <name>` or by finding it in `algolia crawler list`.
+
+### No config-update or delete command
+The CLI can create crawlers but has no command to *update* an existing crawler's config or to *delete* one. To change a config, re-create the crawler (delete the old one first). Crawler deletion is done from the Algolia dashboard.
+
+### `initialIndexSettings` often doesn't apply
+Even when stored correctly in the config, `initialIndexSettings` frequently does not get applied to the index on the first crawl — the index comes up with null settings, so `filters`/facets silently fail. **Always apply settings explicitly** with `algolia settings import` after the index exists ([rag-index-settings.md](rag-index-settings.md)). A scheduled reindex also does not re-apply settings.

--- a/skills/algolia-crawler/references/cli.md
+++ b/skills/algolia-crawler/references/cli.md
@@ -28,7 +28,7 @@ You can also store them in a profile at `~/.config/algolia/config.toml` (`crawle
 # --- crawler lifecycle ---
 algolia crawler create <name> -F config.json     # create (prints nothing on success)
 algolia crawler list                              # list crawlers (find an id)
-algolia crawler get <id|name>                     # inspect crawler + config + status
+algolia crawler get <id>                          # inspect crawler + config + status (UUID only, not a name)
 algolia crawler test <id> --url <url> [-F cfg]    # extract records WITHOUT indexing
 algolia crawler reindex <id>                      # start a crawl that writes records
 algolia crawler run <id> | pause <id>             # resume / pause
@@ -56,10 +56,17 @@ json: cannot unmarshal object into Go struct field Config.config.renderJavaScrip
 This breaks `crawler get`, `crawler list`, and `crawler create -F` for that config. So:
 
 - **Use `renderJavaScript: true`.** In practice the default render wait is enough for most pages — validate with `crawler test` (empty field/score values mean the page needs more render time).
-- `crawler list` fails account-wide if *any* crawler in the app uses a non-boolean `renderJavaScript` — even one you didn't create. If `list` errors with the message above, use `crawler get <name>` to work with your specific crawler.
+- `crawler list` fails account-wide if *any* crawler in the app uses a non-boolean `renderJavaScript` — even one you didn't create. When `list` errors with the message above, use `crawler get <id>` for a crawler whose id you already have, or recover the id via the REST list endpoint (see the id-recovery note above) — `get` cannot look a crawler up by name.
 
-### `create` prints nothing on success
-`algolia crawler create` returns silently — it does not echo the new crawler id. Recover it right after with `algolia crawler get <name>` or by finding it in `algolia crawler list`.
+### `create` prints nothing on success — and id recovery can be fiddly
+`algolia crawler create` returns silently — it does not echo the new crawler id. Recover it from `algolia crawler list`. Note `algolia crawler get` takes a **UUID only** — passing a crawler *name* returns `malformed_id`, so `get <name>` is not a recovery path.
+
+If `list` itself errors (see the `renderJavaScript` gotcha below — one non-boolean crawler anywhere in the account breaks it), there is **no pure-CLI way to get the id**. Fall back to the Crawler REST list endpoint:
+
+```bash
+curl -sS -u "$ALGOLIA_CRAWLER_USER_ID:$ALGOLIA_CRAWLER_API_KEY" \
+  "https://crawler.algolia.com/api/1/crawlers?name=<crawler-name>" | jq -r '.items[0].id'
+```
 
 ### No config-update or delete command
 The CLI can create crawlers but has no command to *update* an existing crawler's config or to *delete* one. To change a config, re-create the crawler (delete the old one first). Crawler deletion is done from the Algolia dashboard.

--- a/skills/algolia-crawler/references/javascript-rendering.md
+++ b/skills/algolia-crawler/references/javascript-rendering.md
@@ -1,0 +1,36 @@
+# Handling JavaScript-rendered pages
+
+Many modern pages ship a nearly-empty HTML shell and load their real content via JavaScript/XHR after the page loads. A default crawl fetches only the initial HTML, so it indexes placeholders instead of data — the single most common reason a crawl produces empty or useless records.
+
+## Detect it
+
+Signs the page is JS-rendered:
+
+- The raw HTML (View Source, or `curl` the URL) shows `Loading…`, empty containers, or skeleton placeholders where the real content should be.
+- The numbers/table/list only appear after the page finishes loading in a browser.
+- `algolia crawler test` (without rendering) returns empty fields, or far fewer records than the page visibly shows.
+
+## Enable rendering
+
+Turn on `renderJavaScript` in the config so the Crawler runs a headless browser and extracts from the rendered DOM:
+
+```json
+{ "renderJavaScript": true }
+```
+
+**Use the boolean `true`, not the object form.** The object form (`{ "enabled": true, "patterns": [...], "waitTime": {...} }`) gives finer control (which URLs to render, how long to wait) but the **Algolia CLI cannot parse it** — it breaks `crawler get`/`list`/`create -F`. For a CLI-managed crawler, `renderJavaScript: true` renders every matched page with the default wait, which is enough for the large majority of pages. See [cli.md](cli.md#the-renderjavascript-gotcha).
+
+## Confirm it worked
+
+Always validate with the test endpoint before a full crawl:
+
+```bash
+algolia crawler test "$CID" --url "https://example.com/page/" | jq '.records[0].records[0]'
+```
+
+- If fields are now populated → rendering is working; proceed.
+- If fields are still empty → the content likely needs more time to load than the default wait allows. Because the CLI only supports the boolean form, your options are to confirm the data truly is in the rendered DOM (inspect via the DOM-dump trick in [workflow.md](workflow.md#validate-before-you-index)), simplify selectors, or — for pages that genuinely need a long custom `waitTime` — configure that crawler from the Algolia dashboard, which supports the full `renderJavaScript` object.
+
+## Performance note
+
+Rendering runs a headless browser per page, so it's slower than plain HTML crawling. With the boolean form it applies to every matched page; keep the crawl scoped (`discoveryPatterns`, `maxUrls`) so you only render the pages you actually need.

--- a/skills/algolia-crawler/references/rag-index-settings.md
+++ b/skills/algolia-crawler/references/rag-index-settings.md
@@ -1,0 +1,42 @@
+# Index settings for RAG retrieval
+
+Apply these **explicitly** after the first crawl — do not rely on the crawler's `initialIndexSettings`, which frequently fails to apply and leaves the index with default (null) settings, so `filters` and facets silently return nothing. See [workflow.md](workflow.md#5-apply-index-settings-explicitly) for the `algolia settings import` command.
+
+## Recommended baseline
+
+```json
+{
+  "searchableAttributes": ["content", "question", "model", "section_title", "page_title"],
+  "attributesForFaceting": [
+    "searchable(record_type)",
+    "searchable(provider)",
+    "searchable(model)"
+  ],
+  "customRanking": ["asc(order)"],
+  "attributesToSnippet": ["content:80"],
+  "attributesToHighlight": ["content"],
+  "distinct": 0
+}
+```
+
+Why these choices for RAG:
+
+- **`searchableAttributes` with `content` first.** `content` holds the natural-language text your retrieval matches against; ordering it first weights it highest.
+- **`attributesForFaceting` with `searchable(...)`.** Lets the RAG layer scope retrieval with `filters` (e.g. `record_type:faq`) *and* get facet counts. Use `filterOnly(attr)` if you only need filtering and not counts — but note `filterOnly` attributes don't appear in facet results, which surprises people.
+- **`customRanking: ["asc(order)"]`.** The `order` you set in the extractor gives a stable, meaningful tiebreak (rank, document order) when text relevance ties.
+- **`distinct: 0`.** RAG wants recall — keep every chunk. Only raise it if near-duplicate records hurt.
+
+## Add semantic retrieval (NeuralSearch / vectors)
+
+Keyword search alone misses paraphrased questions ("how do I cancel" vs. a doc titled "Ending your subscription"). For RAG, enable Algolia's **NeuralSearch** on the index (dashboard → index → NeuralSearch, or via the API) so retrieval is hybrid keyword + semantic over your `content` field. This is usually the biggest single lever on retrieval quality — recommend it whenever the user's queries will be natural-language questions.
+
+## Query-time settings for RAG
+
+Retrieval quality is also a query-time concern. When the RAG layer queries the index:
+
+- **`removeWordsIfNoResults: "allOptional"`** (or set `optionalWords`) so a long natural-language question still returns hits when not every word matches. Default AND-matching returns nothing for "which model hallucinates least" against records that don't contain all those words.
+- **`attributesToRetrieve`** — return only what the LLM needs (`content`, `url`, key attributes) to keep the context lean.
+- **`filters`** — scope to the right `record_type`/category for the question.
+- **`hitsPerPage`** — retrieve a handful (3–8) of chunks to assemble into the prompt.
+
+These live in the query, not the index settings, so they're set by whatever does retrieval (Agent Studio, your app, etc.) — see **algobot-cli** for building that layer.

--- a/skills/algolia-crawler/references/record-extractor.md
+++ b/skills/algolia-crawler/references/record-extractor.md
@@ -1,0 +1,135 @@
+# Writing a RAG-optimized recordExtractor
+
+The `recordExtractor` is a JavaScript function the Crawler runs on each page. It receives `{ url, $, helpers, contentLength, fileType, dataSources }` and returns an array of records. `$` is a [Cheerio](https://cheerio.js.org/) instance over the (optionally JS-rendered) HTML.
+
+In the crawler config the function is stored as a string (`{"__type":"function","source":"…"}`) — that's what `algolia crawler create -F config.json` reads. **The source runs as plain JavaScript — no TypeScript.** Strip any type annotations (`: string[]`, `as any`); they are syntax errors at runtime.
+
+## Emit one record per retrieval unit
+
+Don't return one record per page. Return one per *idea* — a section, a Q&A, a table row/entity. Use a `record_type` discriminator so you can filter by kind later, and give every record a natural-language `content` field plus clean structured attributes.
+
+```js
+({ url, $ }) => {
+  const records = [];
+  const clean = (s) => (s || "").replace(/\s+/g, " ").trim();
+  const pageTitle = clean($("title").first().text()) || clean($("h1").first().text());
+
+  // 1) One record per entity/row — synthesize prose from the structured fields.
+  const rows = $("SELECTOR_FOR_EACH_ROW");
+  rows.each((r) => {
+    const row = rows.eq(r);                       // .eq(i), not $(el) — see below
+    const name = clean(row.find("SELECTOR_NAME").first().text());
+    if (!name) return;
+    const value = clean(row.find("SELECTOR_VALUE").first().text());
+
+    records.push({
+      objectID: "row:" + name.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+      record_type: "row",
+      name,
+      value,                                       // structured attribute (filter/facet)
+      content: `${name}: ${value}.`,               // prose the LLM can cite directly
+      page_title: pageTitle,
+      url: url.href,
+      order: r,
+    });
+  });
+
+  // 2) FAQ -> one record per Q&A pair (excellent RAG units).
+  const faqs = $("SELECTOR_FAQ_ITEM");
+  faqs.each((i) => {
+    const item = faqs.eq(i);
+    const q = clean(item.find("SELECTOR_QUESTION").first().text());
+    const a = clean(item.find("SELECTOR_ANSWER").first().text());
+    if (!q || !a) return;
+    records.push({
+      objectID: "faq:" + i,
+      record_type: "faq",
+      question: q,
+      content: `Q: ${q}\nA: ${a}`,
+      page_title: pageTitle,
+      url: url.href + "#faq-" + i,
+      order: 1000 + i,
+    });
+  });
+
+  // 3) Long prose -> chunked records (see "Chunking long prose").
+  // ...
+
+  return records;
+};
+```
+
+## Reading values from attributes
+
+Rendered pages frequently keep the real value in an **attribute** while the visible cell shows only a bar, badge, or delta. Always check attributes:
+
+```js
+const tip = cell.attr("data-tip") || "";                 // e.g. "Score: <strong>79.8%</strong> [78.1–81.4%]"
+const strong = (tip.match(/<strong>([^<]+)<\/strong>/) || [])[1];
+const value = strong || clean(cell.text());              // prefer the attribute value
+```
+
+When your extracted values look wrong (mangled, empty, or a UI label like "Best"), dump the element's `.html()` and its attributes via the test endpoint (see [workflow.md](workflow.md#validate-before-you-index)) to find where the real data lives.
+
+## Iterate with `.eq(i)`, don't re-wrap elements
+
+Use `collection.eq(i)` to get a properly-typed Cheerio node instead of `$(el)`. Re-wrapping raw elements (`$(el)`, `$(th)`) is what triggers Cheerio `Element`/`Node` type errors in typed editors, and chained mutations like `.clone().find().remove().end()` cause `this`-context errors. Prefer:
+
+```js
+const cells = row.children("td");
+cells.each((i) => { const c = cells.eq(i); /* … */ });
+```
+
+To read an answer that excludes its question without a fragile clone chain, slice the string instead:
+
+```js
+const full = clean(item.text());
+const a = full.startsWith(q) ? full.slice(q.length).trim() : full;
+```
+
+## Chunking long prose
+
+Keep records small — roughly 500–1000 tokens retrieves far better than one giant record. Two options:
+
+**Built-in helper** — `helpers.splitContentIntoRecords` extracts text from elements and splits it into multiple records under a byte cap, sharing a `baseRecord`:
+
+```js
+const proseRecords = helpers.splitContentIntoRecords({
+  $elements: $("article").find("h2, h3, p, li"),
+  baseRecord: { record_type: "section", page_title: pageTitle, url: url.href },
+  maxRecordBytes: 4000,          // smaller chunks = better RAG recall
+  orderingAttributeName: "part",
+});
+```
+
+If the typed signature complains in an editor, cast just that argument: `$elements: $("article").find("h2, h3, p, li") as any` — but remember to remove the `as any` before putting the source in the config (it must be plain JS).
+
+**Manual chunking** — when you want full control over chunk boundaries and want each chunk prefixed with its section heading (so it stays self-contained):
+
+```js
+const CH = 1400; let part = 0;
+for (let s = 0; s < text.length; s += CH) {
+  records.push({
+    objectID: `section:${i}:${part}`,
+    record_type: "section",
+    section_title: heading,
+    content: (heading ? heading + " — " : "") + text.slice(s, s + CH),
+    page_title: pageTitle, url: url.href, order: 2000 + i * 10 + part,
+  });
+  part++;
+}
+```
+
+## Other built-in helpers
+
+The Crawler ships extractors that produce well-shaped records for common page types — reach for these before hand-rolling:
+
+- `helpers.docsearch({ recordProps })` — hierarchical docs content (heading levels `lvl0`–`lvl6` + content). Good for documentation and long structured articles.
+- `helpers.article()` / `helpers.page()` / `helpers.product()` — pull structured data from `og:`/JSON-LD article, generic page, and product schemas.
+- `helpers.codeSnippets()` — extract fenced/`<pre>` code blocks with language.
+
+For a data-heavy page (tables, leaderboards), a hand-written extractor that emits one prose+attributes record per row usually beats the generic helpers.
+
+## Stable objectIDs
+
+Use deterministic `objectID`s derived from the content (`faq:0`, `row:<slug>`), not random ones. Then re-crawls update records in place and remove stale ones, instead of duplicating.

--- a/skills/algolia-crawler/references/site-crawls.md
+++ b/skills/algolia-crawler/references/site-crawls.md
@@ -1,0 +1,92 @@
+# Crawling a whole site or section (multiple pages)
+
+When the user gives a single URL but wants everything under it indexed, two things must be true: the crawler has to discover and follow sub-pages, and — more importantly — your extractor and index settings must be shaped from **all the page shapes it will hit**, not just the start page. A config fitted to the landing page produces junk on the article/reference/blog templates it never saw. This is the most common way a site-wide crawl yields a bad index.
+
+## 1. Let the crawler discover sub-pages
+
+The Crawler follows links from `startUrls`. Control coverage with:
+
+- `startUrls` — entry point(s).
+- `sitemaps` — point at the site's `sitemap.xml` for reliable, complete discovery. Prefer this whenever the site has one.
+- `discoveryPatterns` — which URLs the crawler is allowed to follow (the section you want).
+- `pathsToMatch` (per action) — which discovered URLs actually get extracted/indexed.
+- `maxDepth` / `maxUrls` — depth and count ceilings. For a real site these are *ceilings*, not throttles — raise them (e.g. `maxDepth: 5`, `maxUrls: 2000`). Scoping is about **excluding noise** (assets, unrelated sections), not staying on one page.
+
+```jsonc
+"startUrls": ["https://docs.example.com/"],
+"sitemaps": ["https://docs.example.com/sitemap.xml"],
+"discoveryPatterns": ["https://docs.example.com/**"],
+"maxDepth": 5,
+"maxUrls": 2000,
+```
+
+## 2. Find the distinct page templates
+
+A site is rarely one shape. Before writing the extractor, learn the range:
+
+- Get the URL list from the sitemap, or run a shallow discovery crawl and read what was fetched (`algolia crawler stats <id>` and the crawler's URL report show the crawled URLs).
+- Cluster the URLs by path pattern — `/docs/**`, `/api/**`, `/blog/**`, `/changelog/**`. Each cluster is usually a distinct template with a distinct DOM.
+- Open one URL from each cluster and confirm whether the markup differs enough to need different extraction.
+
+## 3. Sample representative pages — validate against each, not one
+
+This is the core of "take all the pages into account." Pick 2–3 representative URLs **per template** and run `crawler test --url` against **each** — not just the start page:
+
+```bash
+for u in \
+  "https://docs.example.com/getting-started" \
+  "https://docs.example.com/api/search" \
+  "https://docs.example.com/blog/2026-launch"; do
+  echo "== $u =="
+  algolia crawler test "$CID" --url "$u" | jq '.records[0].records | {n: length, first_type: .[0].record_type}'
+done
+```
+
+You're confirming that *every* template yields sensible records. Empty results or wrong fields on one template mean the extractor doesn't generalize yet — fix it before indexing.
+
+## 4. Handle the variety — one branching extractor, or multiple actions
+
+Two ways to cover heterogeneous templates:
+
+**A. One `recordExtractor` that branches on page type.** Detect the template from the URL or DOM and extract accordingly. Simple; everything stays in one function.
+
+```js
+({ url, $, helpers }) => {
+  const path = new URL(url.href).pathname;
+  if (path.startsWith("/api/"))  return extractApiRef($, url);
+  if (path.startsWith("/blog/")) return extractArticle($, url);
+  return extractDoc($, url, helpers);   // default docs template
+};
+```
+
+**B. Multiple `actions`, one per template.** Each action has its own `pathsToMatch` + `recordExtractor`, all writing to the same index. Cleaner when templates differ a lot, and lets you use different helpers per type (e.g. `helpers.docsearch` for docs, a hand-written extractor for the API reference).
+
+```jsonc
+"actions": [
+  { "indexName": "content", "pathsToMatch": ["https://docs.example.com/api/**"],  "recordExtractor": { "__type": "function", "source": "…" } },
+  { "indexName": "content", "pathsToMatch": ["https://docs.example.com/blog/**"], "recordExtractor": { "__type": "function", "source": "…" } },
+  { "indexName": "content", "pathsToMatch": ["https://docs.example.com/**"],      "recordExtractor": { "__type": "function", "source": "…" } }
+]
+```
+
+Order matters: the Crawler applies the **first** action whose `pathsToMatch` matches, so put specific patterns before the catch-all (`/**`) at the end. Give every record a `record_type` so retrieval can tell templates apart.
+
+## 5. Unify settings, then verify across templates
+
+All templates share one index, so a single set of index settings must serve them all — make sure `searchableAttributes` / `attributesForFaceting` cover the fields **every** template produces (see [rag-index-settings.md](rag-index-settings.md)). Apply them explicitly with `algolia settings import` (as always — `initialIndexSettings` isn't reliable).
+
+Then verify with queries that span the whole site, not one page:
+
+```bash
+for q in "how do I authenticate" "search endpoint parameters" "latest release notes"; do
+  echo "== $q =="
+  algolia search content --application-id "$APP_ID" --api-key "$SEARCH_KEY" \
+    --query "$q" --hitsPerPage 2 --attributesToRetrieve "record_type,content,url"
+done
+```
+
+If one template's questions return nothing or junk, go back to step 3 for that template.
+
+## Rule of thumb
+
+Discover the whole set → group into templates → sample and test **each** template → branch or multi-action to cover them → one unified settings + a cross-template verify. Fitting the config to a single page is the most common cause of a bad site-wide index.

--- a/skills/algolia-crawler/references/workflow.md
+++ b/skills/algolia-crawler/references/workflow.md
@@ -1,0 +1,107 @@
+# End-to-end workflow (CLI)
+
+The complete run to take one or more web pages from zero to a verified, RAG-optimized Algolia index, using the **Algolia CLI**. Adapt the placeholders (`YOUR_APP_ID`, URLs, index name, selectors) to the customer's case. Credentials and CLI gotchas are in [cli.md](cli.md).
+
+## 1. Decide the index shape first
+
+Before writing anything, look at the target page(s) and decide what a good *retrieval unit* is:
+
+- A docs/article/marketing page → one record per section (heading + prose), plus one record per FAQ Q&A.
+- A data page (table, leaderboard, pricing, catalog) → one record per row/entity, with a synthesized natural-language `content` field **and** the structured columns as attributes.
+
+Keep records small and self-contained (see the RAG record mental model in SKILL.md).
+
+## 2. Write the config
+
+A Crawler config is a JSON file. The `recordExtractor` is stored as `{"__type": "function", "source": "<stringified function>"}`. Build it safely with `jq --rawfile` so quotes/newlines in the function don't break the JSON:
+
+```bash
+# extractor.js holds the recordExtractor function (see record-extractor.md)
+jq -n --arg appId "$APP_ID" --arg apiKey "$WRITE_KEY" --rawfile src extractor.js '{
+  appId: $appId,
+  apiKey: $apiKey,                       # write key the crawler uses to index
+  indexPrefix: "kb_",
+  startUrls: ["https://example.com/page/"],
+  discoveryPatterns: ["https://example.com/page/**"],   # keep the crawl scoped
+  exclusionPatterns: ["https://example.com/page/**/*.{png,jpg,svg,css,js}"],
+  ignoreQueryParams: ["utm_*","ref","fbclid"],
+  maxDepth: 2, maxUrls: 100, rateLimit: 8,
+  renderJavaScript: true,                # boolean form — required by the CLI (see cli.md)
+  schedule: "every 1 day at 3:00 am",
+  actions: [{
+    indexName: "content",                # final index = indexPrefix + indexName = kb_content
+    pathsToMatch: ["https://example.com/page/**"],
+    recordExtractor: { "__type": "function", source: $src }
+  }]
+}' > config.json
+```
+
+Scope the crawl tightly (`discoveryPatterns`, `maxDepth`, `maxUrls`) so it does not wander the whole domain. Keep `renderJavaScript` a boolean — the CLI rejects the object form ([cli.md](cli.md#the-renderjavascript-gotcha)).
+
+## 3. Create the crawler
+
+```bash
+algolia crawler create my-crawler -F config.json   # prints nothing on success
+CID=$(algolia crawler list | grep -i my-crawler | awk '{print $1}')   # recover the id
+algolia crawler get "$CID" | jq '{name, renderJavaScript: .config.renderJavaScript}'
+```
+
+`create` is silent on success, so fetch the id afterward with `crawler list` (or `crawler get my-crawler`). See [cli.md](cli.md#gotchas).
+
+## 4. Validate before you index
+
+This is the most important step. `crawler test` runs the config against a live URL and returns the records it *would* produce **without indexing anything**. Iterate here, not on live crawls.
+
+```bash
+algolia crawler test "$CID" --url "https://example.com/page/" \
+  | jq '.records[0].records[0]'          # inspect the first extracted record
+```
+
+To try selector changes without touching the stored crawler, pass an override config: `algolia crawler test "$CID" --url … -F trial-config.json`. Check that:
+
+- Records have real values, not empty fields (empty = rendering too slow or wrong selectors).
+- The `content` field reads as a useful, self-contained sentence.
+- Record counts match what you expect (N rows, M FAQs, etc.).
+
+**Debugging tip — use `crawler test` as a DOM inspector.** If selectors return nothing, temporarily return the raw markup so you can see the real rendered structure, then fix your selectors:
+
+```js
+({ $ }) => [{ objectID: "debug", html: $("table").first().html()?.slice(0, 2000) }]
+```
+
+Put that in a trial config, run `crawler test … -F trial-config.json`, read the HTML, adjust selectors, repeat until records look right.
+
+## 5. Apply index settings explicitly
+
+Do **not** rely on `initialIndexSettings` in the config — in practice it often does not get applied, leaving `searchableAttributes`/`attributesForFaceting` unset (so filters and facets silently fail). Apply them yourself after the index exists. See [rag-index-settings.md](rag-index-settings.md) for the recommended `settings.json`.
+
+```bash
+algolia settings import kb_content \
+  --application-id "$APP_ID" --api-key "$WRITE_KEY" \
+  -F settings.json --wait
+```
+
+## 6. Reindex (the crawl that writes records)
+
+```bash
+algolia crawler reindex "$CID"
+```
+
+Returns quickly; the crawl runs async. Poll with `algolia crawler get "$CID"` (watch `lastReindexEndedAt`) or `algolia crawler stats "$CID"` until it reports done.
+
+## 7. Verify by searching
+
+Query the index the way a RAG system will, and confirm you get sensible hits:
+
+```bash
+algolia search kb_content --application-id "$APP_ID" --api-key "$SEARCH_KEY" \
+  --query "a realistic user question" --hitsPerPage 3 \
+  --attributesToRetrieve "content,url"
+# confirm facets/filters work too, e.g. --filters "record_type:faq"
+```
+
+If the empty-query `nbHits` matches your expected record count and targeted queries return the right records, the index is ready. Hand off to **algobot-cli** to build the retrieval/agent layer on top.
+
+## 8. Keep it fresh
+
+The `schedule` field (Later.js text syntax, e.g. `"every 1 day at 3:00 am"`) triggers recurring reindexes. Note that a scheduled reindex reuses the stored config but does **not** re-apply settings — so if you change settings, run the `settings import` from step 5 again.

--- a/skills/algolia-crawler/references/workflow.md
+++ b/skills/algolia-crawler/references/workflow.md
@@ -49,7 +49,7 @@ CID=$(algolia crawler list | grep -i my-crawler | awk '{print $1}')   # recover 
 algolia crawler get "$CID" | jq '{name, renderJavaScript: .config.renderJavaScript}'
 ```
 
-`create` is silent on success, so fetch the id afterward with `crawler list` (or `crawler get my-crawler`). See [cli.md](cli.md#gotchas).
+`create` is silent on success, so fetch the id afterward from `crawler list` (as above) — `crawler get` needs a UUID, not a name. If `list` errors because another crawler in the account uses a non-boolean `renderJavaScript`, recover the id via the REST list endpoint instead. See [cli.md](cli.md#gotchas).
 
 ## 4. Validate before you index
 

--- a/skills/algolia-crawler/references/workflow.md
+++ b/skills/algolia-crawler/references/workflow.md
@@ -11,6 +11,8 @@ Before writing anything, look at the target page(s) and decide what a good *retr
 
 Keep records small and self-contained (see the RAG record mental model in SKILL.md).
 
+**Indexing a whole site or section?** First map the page *templates* you'll crawl (e.g. docs vs API reference vs blog) — each may need its own extraction, and one config has to work for all of them. See [site-crawls.md](site-crawls.md) for the discover → group → sample → cover workflow; the steps below then apply per template.
+
 ## 2. Write the config
 
 A Crawler config is a JSON file. The `recordExtractor` is stored as `{"__type": "function", "source": "<stringified function>"}`. Build it safely with `jq --rawfile` so quotes/newlines in the function don't break the JSON:
@@ -22,7 +24,8 @@ jq -n --arg appId "$APP_ID" --arg apiKey "$WRITE_KEY" --rawfile src extractor.js
   apiKey: $apiKey,                       # write key the crawler uses to index
   indexPrefix: "kb_",
   startUrls: ["https://example.com/page/"],
-  discoveryPatterns: ["https://example.com/page/**"],   # keep the crawl scoped
+  sitemaps: ["https://example.com/sitemap.xml"],        # optional: reliable sub-page discovery
+  discoveryPatterns: ["https://example.com/page/**"],   # URLs the crawler may follow
   exclusionPatterns: ["https://example.com/page/**/*.{png,jpg,svg,css,js}"],
   ignoreQueryParams: ["utm_*","ref","fbclid"],
   maxDepth: 2, maxUrls: 100, rateLimit: 8,
@@ -36,7 +39,7 @@ jq -n --arg appId "$APP_ID" --arg apiKey "$WRITE_KEY" --rawfile src extractor.js
 }' > config.json
 ```
 
-Scope the crawl tightly (`discoveryPatterns`, `maxDepth`, `maxUrls`) so it does not wander the whole domain. Keep `renderJavaScript` a boolean — the CLI rejects the object form ([cli.md](cli.md#the-renderjavascript-gotcha)).
+Scope the crawl to the section you want with `discoveryPatterns` (exclude assets and unrelated paths) instead of the whole domain — but raise `maxDepth`/`maxUrls` enough to cover all the sub-pages you *do* want. For a multi-template site, see [site-crawls.md](site-crawls.md). Keep `renderJavaScript` a boolean — the CLI rejects the object form ([cli.md](cli.md#the-renderjavascript-gotcha)).
 
 ## 3. Create the crawler
 
@@ -50,7 +53,7 @@ algolia crawler get "$CID" | jq '{name, renderJavaScript: .config.renderJavaScri
 
 ## 4. Validate before you index
 
-This is the most important step. `crawler test` runs the config against a live URL and returns the records it *would* produce **without indexing anything**. Iterate here, not on live crawls.
+This is the most important step. `crawler test` runs the config against a live URL and returns the records it *would* produce **without indexing anything**. Iterate here, not on live crawls. For a site-wide crawl, run it against a representative URL from **each** page template, not just one — see [site-crawls.md](site-crawls.md).
 
 ```bash
 algolia crawler test "$CID" --url "https://example.com/page/" \


### PR DESCRIPTION
## What does this skill do?

Guides Algolia customers to crawl one or more web pages into a **RAG-optimized** Algolia index using the Algolia CLI — inspect the page (including JS-rendered), write a RAG-shaped `recordExtractor`, validate with `algolia crawler test` **before** indexing, apply index settings explicitly, then reindex.

## Why

None of the existing skills cover the **Crawler** (ingestion). `algolia-crawler` fills the gap between `algolia-cli` (index ops) and `algobot-cli` (the RAG/agent layer): it gets web content *into* Algolia in a shape that retrieves well for RAG, then hands off to `algobot-cli` for the agent.

## What's inside

- `SKILL.md` — the RAG record mental model + the end-to-end workflow + the two gotchas that bite (JS-rendered data, values hidden in attributes).
- `references/` — `workflow`, `record-extractor` (RAG record patterns, reading values from attributes, chunking), `rag-index-settings` (incl. NeuralSearch), `javascript-rendering`, `cli`.
- `evals/` — 3 realistic scenarios with expectations + `EVAL_RESULTS.md`.

**CLI-only by design** — every step is an `algolia crawler …` / `algolia settings` / `algolia search` command. It bakes in CLI-specific realities verified in practice: the CLI accepts only **boolean** `renderJavaScript` (the object form breaks `get`/`list`/`create -F`), `crawler create` prints nothing (recover the id via `list`), and `initialIndexSettings` frequently doesn't apply so settings must be applied explicitly with `settings import`.

## Evaluation

With-skill vs baseline across the 3 scenarios: **100% vs ~71%** assertion pass rate. The skill's value concentrates on CLI correctness + non-obvious gotchas — a capable model already handles generic RAG record shaping. See `skills/algolia-crawler/evals/EVAL_RESULTS.md`.

## Checklist

- [x] `python3 scripts/validate_skills.py .` passes (0 errors)
- [x] Skill description is under 1024 chars and includes WHEN and WHEN NOT to trigger
- [x] `evals/evals.json` exists with at least 1 realistic prompt
- [x] Skill is self-contained — no `../other-skill/` references
- [x] Registered in `.claude-plugin/marketplace.json` (new skills only)
- [x] Goes in `skills/` here (useful to customers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
