### PR TITLE
docs: list algolia-crawler in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 | `algolia-cli`   | Manage indices, settings, rules, and synonyms via the Algolia CLI                  |
 | `algobot-cli`   | AI agents, Agent Studio, RAG, and conversational experiences built on Algolia      |
 | `instantsearch` | Build search UIs (autocomplete, search results, faceted search) with InstantSearch |
+| `algolia-crawler` | Crawl web pages or whole sites into a RAG-optimized index with the Algolia Crawler |
 
 ---
 
@@ -27,13 +28,13 @@
 
 ```bash
 /plugin marketplace add algolia/skills
-/plugin install <skill>   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch
+/plugin install <skill>   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch, algolia-crawler
 ```
 
 Or install directly:
 
 ```bash
-/plugin install <skill>@algolia-skills   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch
+/plugin install <skill>@algolia-skills   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch, algolia-crawler
 ```
 
 #### npx
@@ -46,7 +47,7 @@ npx skills add https://github.com/algolia/skills
 
 ```bash
 git clone https://github.com/algolia/skills.git
-cp -r skills/<skill> <skills-directory>   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch
+cp -r skills/<skill> <skills-directory>   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch, algolia-crawler
 ```
 
 <details>


### PR DESCRIPTION
## What does this skill do?

Docs-only follow-up: the `algolia-crawler` skill (merged in #27) wasn't listed in the README skills table or the install examples, so it wasn't discoverable from the repo landing page.

## Change

- Add `algolia-crawler` to the **✨ Skills** table.
- Add it to the three `/plugin install` / clone `# e.g. …` examples.

No skill files changed. `python3 scripts/validate_skills.py .` passes (38/0).

## Checklist

- [x] `python3 scripts/validate_skills.py .` passes (0 errors)
- [x] Docs-only — no new skill, no marketplace.json change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
