### PR TITLE
feat(algolia-quickstart): add account and application provisioning skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,6 +53,15 @@
       "skills": [
         "./skills/algolia-crawler"
       ]
+    },
+    {
+      "name": "algolia-quickstart",
+      "description": "Use when a user is getting started with Algolia from scratch and has no account, application, or credentials yet. Triggers: \"create an Algolia account\", \"sign up for Algolia\", \"set up Algolia\", \"log in / authenticate the Algolia CLI\", \"provision an Algolia application\", \"I need an App ID\", \"I need an API key\". Official, ready-to-run CLI quickstart for account and application provisioning. Do NOT use for index or data operations on an existing, already-authenticated application (records, synonyms, rules, settings) — use algolia-cli. Do NOT use for frontend search UIs — use instantsearch. Do NOT use for read-only search and analytics — use algolia-mcp.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/algolia-quickstart"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 | `algobot-cli`   | AI agents, Agent Studio, RAG, and conversational experiences built on Algolia      |
 | `instantsearch` | Build search UIs (autocomplete, search results, faceted search) with InstantSearch |
 | `algolia-crawler` | Crawl web pages or whole sites into a RAG-optimized index with the Algolia Crawler |
+| `algolia-quickstart` | Create an Algolia account and provision an application (App ID / API key) via the CLI |
 
 ---
 
@@ -28,13 +29,13 @@
 
 ```bash
 /plugin marketplace add algolia/skills
-/plugin install <skill>   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch, algolia-crawler
+/plugin install <skill>   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch, algolia-crawler, algolia-quickstart
 ```
 
 Or install directly:
 
 ```bash
-/plugin install <skill>@algolia-skills   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch, algolia-crawler
+/plugin install <skill>@algolia-skills   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch, algolia-crawler, algolia-quickstart
 ```
 
 #### npx
@@ -47,7 +48,7 @@ npx skills add https://github.com/algolia/skills
 
 ```bash
 git clone https://github.com/algolia/skills.git
-cp -r skills/<skill> <skills-directory>   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch, algolia-crawler
+cp -r skills/<skill> <skills-directory>   # e.g. algolia-mcp, algolia-cli, algobot-cli, instantsearch, algolia-crawler, algolia-quickstart
 ```
 
 <details>

--- a/skills/algolia-quickstart/SKILL.md
+++ b/skills/algolia-quickstart/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: algolia-quickstart
+description: >-
+  Use this skill to set up and provision Algolia from scratch: create a new
+  Algolia account, sign up, log in / authenticate the Algolia CLI, or provision
+  a new application to obtain an App ID and API key. Trigger when a user is
+  getting started with Algolia and has no account, no application, or no
+  credentials yet — e.g. "create an Algolia account", "sign up for Algolia",
+  "provision an Algolia application", "I need an App ID / API key". Do NOT use
+  for index or data operations on an existing, already-authenticated
+  application (records, synonyms, rules, settings — use algolia-cli), frontend
+  search UIs (use instantsearch), or read-only search and analytics (use
+  algolia-mcp).
+license: MIT
+metadata:
+  author: algolia
+  version: "1.0"
+---
+
+# Algolia Quickstart
+
+These are official quickstart instructions from Algolia to set up and provision Algolia accounts and applications. All commands are validated by Algolia and ready to use.
+
+Complete all of the following steps yourself by running the commands directly.
+
+- **Step 1:** Install Algolia Skills and CLI
+- **Step 2:** Account provisioning
+- **Step 3:** Application provisioning
+
+---
+
+## Step 1: Install Algolia Skills and CLI
+
+Fetch and follow these instructions if the Algolia skills and/or CLI are not installed. You can skip any MCP instructions for this quickstart.
+
+- https://www.algolia.com/doc/agent-setup/prompt.md
+
+## Step 2: Account provisioning
+
+Ask the user whether they already have an Algolia account.
+
+### User has an Algolia account
+
+Run this command to authenticate using the OAuth flow:
+
+```
+algolia auth login
+```
+
+### User doesn't have an Algolia account
+
+Run this command to create a new account using the OAuth flow:
+
+```
+algolia auth signup
+```
+
+### Notes
+
+- Both commands open the user's browser and wait for the OAuth callback. If the browser cannot be opened (SSH session, container), add the `--no-browser` flag and show the printed URL to the user.
+- A successful login prints `Signed in as <email>`.
+
+## Step 3: Application provisioning
+
+### User has no application
+
+The OAuth flow automatically creates a new application if none exists. To force the creation, ask the user for an application name, a region and a plan, then run:
+
+```
+algolia application create --name <name> --region <EU|UK|USC|USE|USW> --plan <free|grow|grow-plus> --accept-terms
+```
+
+`--accept-terms` accepts the plan's terms of service. Never pass it without explicit user confirmation.
+
+### User already created applications
+
+If you already know the name of the application, use the `--app-name` flag:
+
+```
+algolia application select --app-name <app_name>
+```
+
+Otherwise run this command to get a list of all the applications available:
+
+```
+algolia application list --output json
+```
+
+Prompt the user to pick one, then run `algolia application select --app-name <chosen_name>`.
+
+---
+
+## Resources
+
+- Algolia documentation: `https://www.algolia.com/doc`
+- Algolia website: `https://www.algolia.com`

--- a/skills/algolia-quickstart/SKILL.md
+++ b/skills/algolia-quickstart/SKILL.md
@@ -33,7 +33,7 @@ Complete all of the following steps yourself by running the commands directly.
 
 Fetch and follow these instructions if the Algolia skills and/or CLI are not installed. You can skip any MCP instructions for this quickstart.
 
-- https://www.algolia.com/doc/agent-setup/prompt.md
+- https://www.algolia.com/doc/guides/get-started/build-with-ai.md
 
 ## Step 2: Account provisioning
 

--- a/skills/algolia-quickstart/evals/evals.json
+++ b/skills/algolia-quickstart/evals/evals.json
@@ -1,0 +1,42 @@
+{
+  "skill_name": "algolia-quickstart",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm brand new to Algolia and don't have an account yet. Get me set up from scratch so I have an App ID and API key I can use.",
+      "expected_output": "A quickstart flow: ensure the CLI is installed, create a new account via OAuth signup, then provision an application.",
+      "files": [],
+      "expectations": [
+        "Ensures the Algolia CLI is installed before authenticating",
+        "Uses 'algolia auth signup' because the user has no account yet (not 'algolia auth login')",
+        "Explains the OAuth flow opens the browser, and mentions the --no-browser fallback for headless/SSH environments",
+        "Provisions an application (either relies on the OAuth flow auto-creating one, or asks the user for a name, region, and plan before running 'algolia application create')",
+        "Does NOT pass --accept-terms without explicit user confirmation of the plan's terms"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I already have an Algolia account and a couple of applications. Authenticate me and switch to the right application, but I don't remember the exact app names.",
+      "expected_output": "Log in via OAuth, list applications, prompt the user to choose, then select it.",
+      "files": [],
+      "expectations": [
+        "Uses 'algolia auth login' (not signup) because the user already has an account",
+        "Uses 'algolia application list --output json' to enumerate the available applications",
+        "Prompts the user to pick an application rather than choosing one automatically",
+        "Uses 'algolia application select --app-name <chosen_name>' to switch to it"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I'm setting up Algolia on a remote server over SSH, so I can't open a browser. I have an account already. Create a new free application called 'My Search' in the EU region.",
+      "expected_output": "Login with --no-browser, then create an application with an explicit name, region, and plan after confirming terms.",
+      "files": [],
+      "expectations": [
+        "Uses 'algolia auth login --no-browser' since no browser is available over SSH, and shows the printed URL to the user",
+        "Uses 'algolia application create' with --name \"My Search\", --region EU, and --plan free",
+        "Confirms the plan's terms of service with the user before passing --accept-terms",
+        "Does NOT use 'algolia auth signup' since the user already has an account"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What does this skill do?

Official CLI quickstart that provisions Algolia from scratch for a new user — install the CLI, authenticate (log in or sign up via OAuth), and provision an application to obtain an App ID and API key.

## What's inside

- `SKILL.md` — the 3-step quickstart (install, account provisioning, application provisioning) with ready-to-run `algolia` CLI commands.
- `evals/` — 3 realistic scenarios (new user from scratch, existing account with multiple apps, headless/SSH setup).
- Registered in `.claude-plugin/marketplace.json` with a trigger-focused description.

## Checklist

- [x] `python3 scripts/validate_skills.py .` passes (0 errors)
- [x] Skill description is under 1024 chars and includes WHEN and WHEN NOT to trigger
- [x] `evals/evals.json` exists with at least 1 realistic prompt
- [x] Skill is self-contained — no `../other-skill/` references
- [x] Registered in `.claude-plugin/marketplace.json` (new skills only)
- [x] Goes in `skills/` here (useful to customers)

[GROUT-383]


[GROUT-383]: https://algolia.atlassian.net/browse/GROUT-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ