### PR TITLE
docs(algolia-cli): switch getting-started to auth commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "algolia-cli",
-      "description": "Use for any hands-on Algolia admin operation: importing/exporting records, backing up indices, managing API keys, editing synonyms, configuring rules, changing settings (facets, searchable attributes), deleting records, copying/migrating indices, or automating Algolia in CI/CD. Contains exact CLI syntax, ndjson format requirements, and flag combinations that are easy to get wrong from memory. Do NOT use for frontend SDK (InstantSearch, React) or Algolia dashboard UI questions — see algolia-mcp for read-only search and analytics.",
+      "description": "Use for any hands-on Algolia admin operation: provisioning accounts (sign up, log in/out via OAuth), managing applications (create, select, list), importing/exporting records, backing up indices, managing API keys, editing synonyms, configuring rules, changing settings (facets, searchable attributes), deleting records, copying/migrating indices, or automating Algolia in CI/CD. Contains exact CLI syntax, ndjson format requirements, and flag combinations that are easy to get wrong from memory. Do NOT use for frontend SDK (InstantSearch, React) or Algolia dashboard UI questions — see algolia-mcp for read-only search and analytics.",
       "source": "./",
       "strict": false,
       "skills": [

--- a/skills/algolia-cli/references/getting-started.md
+++ b/skills/algolia-cli/references/getting-started.md
@@ -2,9 +2,8 @@
 
 ## Prerequisites
 
-- **Algolia account** — [Sign up free](https://www.algolia.com/users/sign_up)
-- **Application ID** — Found in [Dashboard → Settings → API Keys](https://dashboard.algolia.com/account/api-keys/all)
-- **Admin API key** — Same location. Required for write operations (import, delete, settings).
+- **Algolia account** — Optional upfront: `algolia auth signup` creates one from the CLI. You can also [sign up free](https://www.algolia.com/users/sign_up) on the web.
+- **Application ID and API keys** — Nothing to copy by hand: `algolia auth login` fetches your applications and provisions credentials automatically (stored in your OS keychain).
 
 ## Installation
 

--- a/skills/algolia-cli/references/getting-started.md
+++ b/skills/algolia-cli/references/getting-started.md
@@ -42,19 +42,37 @@ choco install algolia-cli
 algolia --version
 ```
 
-## Profile Setup
+## Authentication
 
-A profile stores your Algolia credentials locally so you don't need to pass them with every command.
+Signing in stores your Algolia credentials locally so you don't need to pass them with every command. `algolia auth login` handles OAuth sign-in and profile creation in one step — no need to copy an API key by hand.
 
-### Create a profile (non-interactive)
+### Sign in
 
 ```bash
-algolia profile add --name "default" --app-id "YOUR_APP_ID" --api-key "YOUR_ADMIN_API_KEY" --default
+algolia auth login
 ```
 
-> **Important:** Always provide all three flags (`--name`, `--app-id`, `--api-key`) to avoid interactive prompts that require terminal input.
+This opens your browser for OAuth sign-in, then fetches your applications, lets you pick one, and creates a CLI profile with the Admin API key.
 
-### Verify the profile
+> **Tip:** On SSH sessions or containers where a browser can't open, use `algolia auth login --no-browser` to print the URL instead.
+
+### Create a new account
+
+If you don't have an Algolia account yet, sign up from the CLI:
+
+```bash
+algolia auth signup
+```
+
+This opens the sign-up page, then completes the same OAuth flow as `login`.
+
+### Verify you're signed in
+
+```bash
+algolia auth status
+```
+
+This shows whether you're signed in, which application is current, and whether API credentials are available. You can also confirm your setup by listing indices:
 
 ```bash
 algolia indices list
@@ -62,33 +80,34 @@ algolia indices list
 
 This should list the indices in your application.
 
-### List existing profiles
+### Sign out
 
 ```bash
-algolia profile list
+algolia auth logout
 ```
+
+This revokes the stored OAuth tokens and removes them from the local keychain.
 
 ### Configuration file location
 
-Profiles are stored in:
+Credentials are stored in:
 
 ```
 ~/.config/algolia/config.toml
 ```
 
-### Multiple profiles
+### Multiple applications
 
-You can add multiple profiles for different applications:
+Select a specific application by name when you sign in:
 
 ```bash
-algolia profile add --name "staging" --app-id "STAGING_ID" --api-key "STAGING_KEY"
-algolia profile add --name "production" --app-id "PROD_ID" --api-key "PROD_KEY" --default
+algolia auth login --app-name "production" --default
 ```
 
-Use `-p <profile>` to target a specific profile:
+Switch the current application at any time:
 
 ```bash
-algolia indices list -p staging
+algolia application select --app-name "staging"
 ```
 
 ## Next Steps

--- a/skills/algolia-cli/references/getting-started.md
+++ b/skills/algolia-cli/references/getting-started.md
@@ -88,13 +88,15 @@ algolia auth logout
 
 This revokes the stored OAuth tokens and removes them from the local keychain.
 
-### Configuration file location
+### Where your credentials are stored
 
-Credentials are stored in:
+Non-secret settings (current application, application aliases, hosts) are stored in:
 
 ```
-~/.config/algolia/config.toml
+~/.config/algolia/state.toml
 ```
+
+Your API keys are never written to this file — they're stored securely in your operating system's keychain.
 
 ### Multiple applications
 


### PR DESCRIPTION
## What does this change do?

Updates the `algolia-cli` skill to reflect the CLI's `auth` commands.

## Changes

- `skills/algolia-cli/references/getting-started.md` — replaces the `algolia profile ...` setup flow with the equivalent `algolia auth ...` commands: `auth login` / `auth signup` for sign-in and account creation, `auth status` to check the current session, and `auth logout`. Multi-application targeting now uses `algolia application select`.
- `.claude-plugin/marketplace.json` — expands the `algolia-cli` description to include account provisioning and application management.

[GROUT-384]

[GROUT-384]: https://algolia.atlassian.net/browse/GROUT-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ