### PR TITLE
feat(agent-studio): add Agent Studio frontend chat skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,6 +62,15 @@
       "skills": [
         "./skills/algolia-quickstart"
       ]
+    },
+    {
+      "name": "agent-studio",
+      "description": "Build agentic chat experiences on your own website with Algolia Agent Studio and the react-instantsearch Chat widget. Use for integrating Agent Studio into a React app, adding a chat widget, creating client-side tools for the chat agent, customizing the chat UI/CSS, sending Algolia Insights (business) events, implementing user authentication with secure tokens, setting up memory/personalization, injecting context into conversations, or creating prompt starters. Do NOT use for building or configuring the agent itself via CLI (use algobot-cli), for raw index operations (use algolia-cli), or for a pure search UI with no chat/agent layer (use instantsearch).",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/agent-studio"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | `instantsearch` | Build search UIs (autocomplete, search results, faceted search) with InstantSearch |
 | `algolia-crawler` | Crawl web pages or whole sites into a RAG-optimized index with the Algolia Crawler |
 | `algolia-quickstart` | Create an Algolia account and provision an application (App ID / API key) via the CLI |
+| `agent-studio`  | Add an Agent Studio chat agent, InstantSearch Chat widget, and business events to your website |
 
 ---
 

--- a/examples/coding-with-ai-nextjs/.env.example
+++ b/examples/coding-with-ai-nextjs/.env.example
@@ -1,0 +1,16 @@
+# ---------------------------------------------------------------------------
+# Client-side config (inlined into the browser bundle — safe to expose).
+# The NEXT_PUBLIC_ prefix is required for values used in Client Components.
+# ---------------------------------------------------------------------------
+NEXT_PUBLIC_ALGOLIA_APP_ID=your-app-id
+NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=your-search-only-api-key
+NEXT_PUBLIC_ALGOLIA_INDEX_NAME=products
+NEXT_PUBLIC_ALGOLIA_AGENT_ID=your-published-agent-id
+
+# ---------------------------------------------------------------------------
+# Server-only secrets — NEVER prefix these with NEXT_PUBLIC.
+# They stay on the server and are read only by the token Route Handler.
+# Get both from Agent Studio: Settings > Authentication.
+# ---------------------------------------------------------------------------
+ALGOLIA_SECRET_KEY=sk-alg-your-secret-key
+ALGOLIA_KEY_ID=your-key-id

--- a/examples/coding-with-ai-nextjs/.gitignore
+++ b/examples/coding-with-ai-nextjs/.gitignore
@@ -1,0 +1,15 @@
+/node_modules
+/.next
+/out
+/build
+
+# local env files (keep .env.example checked in)
+.env
+.env*.local
+
+# logs & misc
+npm-debug.log*
+yarn-error.log*
+.DS_Store
+*.tsbuildinfo
+next-env.d.ts.timestamp

--- a/examples/coding-with-ai-nextjs/README.md
+++ b/examples/coding-with-ai-nextjs/README.md
@@ -1,0 +1,145 @@
+# Coding with AI — Next.js reference app
+
+A minimal, correct-by-construction reference app for embedding Algolia
+InstantSearch and an Agent Studio chat agent in a **Next.js App Router** project.
+It is the canonical thing to diff against: the patterns here are shaped for the
+App Router, not ported from a Vite/SPA example.
+
+## What it demonstrates
+
+- Search UI (`SearchBox` + `Hits`) and a streaming `<Chat>` agent sharing one
+  Algolia client and index.
+- The App Router client/server split: global CSS and metadata on the server; all
+  Algolia and chat UI in Client Components.
+- SSR-safe InstantSearch via `<InstantSearchNext>` from
+  `react-instantsearch-nextjs`.
+- A server-side token endpoint that mints an HS256 JWT so the Agent Studio secret
+  never reaches the browser.
+- Business-events attribution done the library-idiomatic way: the search
+  `queryID` is read from the hit itself (`item.__queryID`) in the chat
+  `itemComponent`. Clicks fire through InstantSearch's built-in `sendEvent`;
+  add-to-cart conversions look up the queryID recorded when the hit rendered.
+  This avoids matching a hardcoded tool name and does not depend on the
+  assistant message's `parts` (the footer component cannot access them).
+- One client-side tool (`add_to_cart`) built with the `layoutComponent` pattern.
+
+## Prerequisites
+
+- Node.js 20 or newer.
+- An Algolia application with a populated index and a **search-only** API key.
+- A **published** Agent Studio agent, and its agent ID.
+- The **secret key** (`sk-alg-…`) and **Key ID** from Agent Studio:
+  **Settings > Authentication**.
+
+## Setup
+
+```bash
+# 1. Configure environment
+cp .env.example .env.local
+#    then fill in the values in .env.local
+
+# 2. Install and run
+npm install
+npm run dev
+```
+
+Open http://localhost:3000. Type a query into the search box, or open the chat
+bubble and ask the agent about products.
+
+Type-check without running the app:
+
+```bash
+npm run typecheck
+```
+
+## Environment variables
+
+Client-side (inlined into the browser bundle — must be `NEXT_PUBLIC_*`):
+
+| Variable | Purpose |
+| --- | --- |
+| `NEXT_PUBLIC_ALGOLIA_APP_ID` | Algolia application ID |
+| `NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY` | Search-only API key |
+| `NEXT_PUBLIC_ALGOLIA_INDEX_NAME` | Index to search (e.g. `products`) |
+| `NEXT_PUBLIC_ALGOLIA_AGENT_ID` | Published Agent Studio agent ID |
+
+Server-only (never prefix with `NEXT_PUBLIC`):
+
+| Variable | Purpose |
+| --- | --- |
+| `ALGOLIA_SECRET_KEY` | Signs the user JWT — from Settings > Authentication |
+| `ALGOLIA_KEY_ID` | JWT header `kid` — from the same page |
+
+## Dashboard configuration (required)
+
+Two things must be set up in the Agent Studio dashboard for this app to work
+end to end:
+
+1. **Define the `add_to_cart` client-side tool.** Under **Tools > Client-side
+   tools**, add a function named exactly `add_to_cart` with parameters
+   `productId` (string) and `quantity` (integer, nullable). The tool name must
+   match the key registered on `<Chat tools={{ add_to_cart: … }}>`. In
+   production set `"strict": true` — then every property must appear in
+   `required`, and optional fields use the union type `["integer", "null"]`.
+
+   ```json
+   {
+     "type": "function",
+     "function": {
+       "name": "add_to_cart",
+       "description": "Adds a product to the user's shopping cart.",
+       "strict": true,
+       "parameters": {
+         "type": "object",
+         "properties": {
+           "productId": { "type": "string", "description": "The Algolia objectID" },
+           "quantity": { "type": ["integer", "null"], "description": "Defaults to 1" }
+         },
+         "required": ["productId", "quantity"],
+         "additionalProperties": false
+       }
+     }
+   }
+   ```
+
+2. **Enable memory with a non-zero retention.** Under **Customizations >
+   Memory**, set data retention to 30/60/90 days (NOT 0) and require user
+   authentication. Memory and conversation scoping depend on the secure user
+   token minted by `app/api/auth/algolia-token/route.ts`.
+
+## What is mocked
+
+This is a starter, not a store. Be aware:
+
+- **The cart is an in-memory stub** (`app/lib/cart.ts`). It is not persisted and
+  not shared with any server — state is lost on refresh. Replace it with a call
+  to your commerce backend.
+- **The authenticated user is hardcoded** (`DEMO_USER_ID` in
+  `app/lib/algolia-token.ts`, and the request body in the token route). Wire both
+  to your real auth/session, and never trust a client-supplied user ID on the
+  server.
+- **The add-to-cart conversion price** falls back to `0.00` when the product was
+  not surfaced by an agent search (so no price was captured). Resolve the
+  authoritative price server-side in a real integration.
+- Product-card fields (`name`, `price`, `image`, `brand`) assume a common index
+  schema. Adjust `ProductHit` in `app/lib/algolia.ts` to match yours.
+
+## File tour
+
+```
+app/
+  layout.tsx                       Server Component: html shell + global CSS
+  providers.tsx                    "use client": <InstantSearchNext> provider
+  page.tsx                         Composes the search UI and the chat widget
+  globals.css                      InstantSearch + chat CSS, plus rebrand tokens
+  api/auth/algolia-token/route.ts  Route Handler: mints the HS256 user JWT
+  components/
+    Search.tsx                     SearchBox + Hits
+    ChatWidget.tsx                 <Chat> transport, tools, attribution wiring
+    AddToCartTool.tsx              add_to_cart handler (layoutComponent pattern)
+  lib/
+    algolia.ts                     Shared search client + config + ProductHit
+    algolia-token.ts               Client helper: fetch + cache the user token
+    insights.ts                    Insights events + queryID attribution from item.__queryID
+    cart.ts                        In-memory cart stub
+```

--- a/examples/coding-with-ai-nextjs/app/api/auth/algolia-token/route.ts
+++ b/examples/coding-with-ai-nextjs/app/api/auth/algolia-token/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import jwt from "jsonwebtoken";
+
+// jsonwebtoken relies on Node crypto, so this handler must run on the Node.js
+// runtime (not the Edge runtime).
+export const runtime = "nodejs";
+
+// POST /api/auth/algolia-token
+//
+// Mints a short-lived HS256 JWT that scopes Agent Studio memory & conversations
+// to a user. The secret is read from a server-only env var and NEVER leaves the
+// server — the browser only ever receives the signed token.
+//
+// Get ALGOLIA_SECRET_KEY (sk-alg-...) and ALGOLIA_KEY_ID from Agent Studio:
+// Settings > Authentication.
+export async function POST(request: Request) {
+  const secret = process.env.ALGOLIA_SECRET_KEY;
+  const keyId = process.env.ALGOLIA_KEY_ID;
+
+  if (!secret || !keyId) {
+    return NextResponse.json(
+      { error: "Server is not configured with ALGOLIA_SECRET_KEY / ALGOLIA_KEY_ID" },
+      { status: 500 }
+    );
+  }
+
+  // In a real app, derive the user ID from the authenticated session — do NOT
+  // trust a client-supplied ID. This demo reads it from the request body.
+  let userId = "anonymous";
+  try {
+    const body = (await request.json()) as { userId?: unknown };
+    if (typeof body?.userId === "string" && body.userId.length > 0) {
+      userId = body.userId;
+    }
+  } catch {
+    // No/invalid body → treat as anonymous.
+  }
+
+  const token = jwt.sign({ sub: userId }, secret, {
+    expiresIn: "24h",
+    header: {
+      alg: "HS256",
+      typ: "JWT",
+      kid: keyId, // Key ID from Agent Studio Settings > Authentication
+    },
+  });
+
+  return NextResponse.json({ token });
+}

--- a/examples/coding-with-ai-nextjs/app/components/AddToCartTool.tsx
+++ b/examples/coding-with-ai-nextjs/app/components/AddToCartTool.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { addToCart } from "../lib/cart";
+import { trackChatAddToCart } from "../lib/insights";
+
+// Client-side tool handler for the `add_to_cart` tool defined in the Agent
+// Studio dashboard. It uses the `layoutComponent` pattern (NOT `onToolCall`):
+// onToolCall runs during the library's stream-processing phase and can deadlock
+// the internal SerialJobExecutor with async work, whereas layoutComponent defers
+// execution to React's render cycle.
+
+// Match the library's ClientSideToolComponentProps, where `input` is `unknown`.
+// Narrow it at runtime inside the effect rather than in the prop type.
+type AddToCartMessage = {
+  state: string;
+  input?: unknown;
+  // The Chat widget passes additional fields we don't need here.
+  [key: string]: unknown;
+};
+
+export function AddToCartTool({
+  message,
+  addToolResult,
+}: {
+  message: AddToCartMessage;
+  addToolResult: (params: { output: unknown }) => void;
+  [key: string]: unknown;
+}) {
+  // Guard against duplicate executions across re-renders.
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (message.state !== "input-available" || handledRef.current) return;
+    handledRef.current = true;
+
+    try {
+      const input = message.input as { productId?: string; quantity?: number | null } | undefined;
+      const productId = input?.productId;
+      const quantity = input?.quantity ?? 1;
+
+      if (!productId) {
+        // Always call addToolResult, even on failure, so the agent can continue.
+        addToolResult({ output: { error: "Missing productId" } });
+        return;
+      }
+
+      const line = addToCart(productId, quantity);
+      // Conversion-after-search: attributed to the agent's search when we have a
+      // queryID for this product (see lib/insights.ts).
+      trackChatAddToCart(productId, quantity);
+
+      addToolResult({
+        output: { success: true, productId, quantity: line.quantity },
+      });
+    } catch (err) {
+      addToolResult({
+        output: { error: err instanceof Error ? err.message : "Add to cart failed" },
+      });
+    }
+  }, [message.state, message.input, addToolResult]);
+
+  // Invisible tool: render an empty fragment (the component must return an
+  // Element, not null, per ClientSideToolComponent).
+  return <></>;
+}

--- a/examples/coding-with-ai-nextjs/app/components/ChatWidget.tsx
+++ b/examples/coding-with-ai-nextjs/app/components/ChatWidget.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Chat } from "react-instantsearch";
+import type { RecommendItemComponentProps, RecordWithObjectID } from "instantsearch-ui-components";
+import { APP_ID, SEARCH_API_KEY, AGENT_ID, type ProductHit } from "../lib/algolia";
+import { fetchAlgoliaToken } from "../lib/algolia-token";
+import { recordSearchHit } from "../lib/insights";
+import { AddToCartTool } from "./AddToCartTool";
+
+// Product card rendered inside the chat's search-result carousel. The
+// itemComponent receives the real InstantSearch props — the hit (`item`) and the
+// built-in `sendEvent` helper. The queryID lives ON THE HIT (`item.__queryID`),
+// so we record it here for the later add-to-cart conversion, and fire clicks
+// through `sendEvent` (InstantSearch derives queryID + position from the hit).
+function ChatProductCard({ item, sendEvent }: RecommendItemComponentProps<RecordWithObjectID<ProductHit>>) {
+  // Remember this hit's queryID + price so trackChatAddToCart can attribute a
+  // later conversion-after-search to the agent's search (see lib/insights.ts).
+  recordSearchHit(item.objectID, item.__queryID, item.price);
+
+  const trackClick = () => sendEvent("click", item, "Product Clicked in Chat");
+
+  return (
+    <div
+      className="chat-hit"
+      role="button"
+      tabIndex={0}
+      onClick={trackClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") trackClick();
+      }}
+    >
+      {item.image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={item.image} alt={item.name ?? item.objectID} className="chat-hit-image" />
+      ) : null}
+      <span className="chat-hit-name">{item.name ?? item.objectID}</span>
+      {item.price != null ? <span className="chat-hit-price">${item.price}</span> : null}
+    </div>
+  );
+}
+
+export function ChatWidget() {
+  return (
+    <Chat
+      transport={{
+        api: `https://${APP_ID}.algolia.net/agent-studio/1/agents/${AGENT_ID}/completions?compatibilityMode=ai-sdk-5`,
+        // compatibilityMode=ai-sdk-5 is REQUIRED when using a custom transport.
+        headers: async () => {
+          const token = await fetchAlgoliaToken();
+          return {
+            "x-algolia-application-id": APP_ID,
+            "x-algolia-api-key": SEARCH_API_KEY,
+            // Optional: scopes memory & conversations to the signed-in user.
+            ...(token ? { "X-Algolia-Secure-User-Token": token } : {}),
+          };
+        },
+      }}
+      tools={{
+        // Key MUST match the tool name configured in the Agent Studio dashboard.
+        add_to_cart: { layoutComponent: AddToCartTool },
+      }}
+      itemComponent={ChatProductCard}
+      translations={{
+        prompt: {
+          textareaPlaceholder: "Ask about our products…",
+          disclaimer: "AI-powered assistant. Responses may not be perfect.",
+        },
+        header: {
+          title: "Shopping assistant",
+        },
+      }}
+    />
+  );
+}

--- a/examples/coding-with-ai-nextjs/app/components/Search.tsx
+++ b/examples/coding-with-ai-nextjs/app/components/Search.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { SearchBox, Hits } from "react-instantsearch";
+import type { ProductHit } from "../lib/algolia";
+
+// A hit rendered in the classic search results grid (separate from the chat
+// carousel). Shares the same searchClient + index as the chat via the
+// InstantSearchNext provider in app/providers.tsx.
+function Hit({ hit }: { hit: ProductHit }) {
+  return (
+    <article className="hit">
+      {hit.image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={hit.image} alt={hit.name ?? hit.objectID} className="hit-image" />
+      ) : null}
+      <h3 className="hit-name">{hit.name ?? hit.objectID}</h3>
+      {hit.brand ? <p className="hit-brand">{hit.brand}</p> : null}
+      {hit.price != null ? <p className="hit-price">${hit.price}</p> : null}
+    </article>
+  );
+}
+
+export function Search() {
+  return (
+    <section className="search">
+      <SearchBox placeholder="Search products…" />
+      <Hits hitComponent={Hit} />
+    </section>
+  );
+}

--- a/examples/coding-with-ai-nextjs/app/globals.css
+++ b/examples/coding-with-ai-nextjs/app/globals.css
@@ -1,0 +1,119 @@
+/* Algolia InstantSearch base styles (resolved from node_modules by Next). */
+@import "instantsearch.css/themes/reset.css";
+@import "instantsearch.css/themes/satellite.css";
+/* Chat widget styles. */
+@import "instantsearch.css/components/chat.css";
+
+:root {
+  --fg: #1a1c1d;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+  --bg: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  color: var(--fg);
+  background: var(--bg);
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  line-height: 1.5;
+}
+
+.page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem 6rem;
+}
+
+.page-header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+}
+
+.page-header p {
+  margin: 0 0 1.5rem;
+  color: var(--muted);
+}
+
+.search .ais-SearchBox {
+  margin-bottom: 1.5rem;
+}
+
+/* Search results grid. */
+.ais-Hits-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.hit {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+}
+
+.hit-image {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 0.5rem;
+}
+
+.hit-name {
+  font-size: 0.95rem;
+  margin: 0.5rem 0 0.25rem;
+}
+
+.hit-brand {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.hit-price {
+  font-weight: 600;
+  margin: 0.25rem 0 0;
+}
+
+/* Product card inside the chat carousel. */
+.chat-hit {
+  display: block;
+  width: 10rem;
+  flex-shrink: 0;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.chat-hit-image {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+}
+
+.chat-hit-name {
+  display: block;
+  padding: 0.5rem 0.5rem 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.chat-hit-price {
+  display: block;
+  padding: 0 0.5rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+/* Rebrand the chat widget with design tokens (see components-and-css.md). */
+.ais-Chat {
+  --ais-primary-color-rgb: 20, 20, 20;
+  --ais-font-family: "Inter", system-ui, sans-serif;
+}

--- a/examples/coding-with-ai-nextjs/app/layout.tsx
+++ b/examples/coding-with-ai-nextjs/app/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+// Root layout is a Server Component. Global CSS is imported here (the App Router
+// convention). Client-side Algolia/chat UI is composed inside the page.
+export const metadata: Metadata = {
+  title: "Coding with AI — Algolia reference app",
+  description: "Algolia InstantSearch + an Agent Studio chat agent on the Next.js App Router.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/coding-with-ai-nextjs/app/lib/algolia-token.ts
+++ b/examples/coding-with-ai-nextjs/app/lib/algolia-token.ts
@@ -1,0 +1,37 @@
+"use client";
+
+// Client-side helper: fetches the secure user token from our own Route Handler
+// (app/api/auth/algolia-token/route.ts) and caches it until shortly before it
+// expires. The Agent Studio secret NEVER reaches the browser — only the minted
+// JWT does. Returns null for anonymous users so the chat still works without
+// memory/personalization.
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+// Stub: a real app derives this from its own auth/session. Swap for the signed-in
+// user's stable ID; use null (skip the fetch) for anonymous visitors.
+const DEMO_USER_ID = "demo-user-123";
+
+export async function fetchAlgoliaToken(): Promise<string | null> {
+  // Reuse the cached token unless it expires within the next 5 minutes.
+  if (cachedToken && cachedToken.expiresAt > Date.now() + 5 * 60 * 1000) {
+    return cachedToken.token;
+  }
+
+  try {
+    const res = await fetch("/api/auth/algolia-token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ userId: DEMO_USER_ID }),
+    });
+    if (!res.ok) return null;
+
+    const { token } = (await res.json()) as { token: string };
+    const payload = JSON.parse(atob(token.split(".")[1])) as { exp: number };
+    cachedToken = { token, expiresAt: payload.exp * 1000 };
+    return token;
+  } catch {
+    // Anonymous fallback: chat works, just without user-scoped memory.
+    return null;
+  }
+}

--- a/examples/coding-with-ai-nextjs/app/lib/algolia.ts
+++ b/examples/coding-with-ai-nextjs/app/lib/algolia.ts
@@ -1,0 +1,24 @@
+import { liteClient } from "algoliasearch/lite";
+
+// Public config. NEXT_PUBLIC_* values are inlined into the client bundle at
+// build time (App Router equivalent of Vite's import.meta.env — NOT the same).
+export const APP_ID = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID!;
+export const SEARCH_API_KEY = process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY!;
+export const INDEX_NAME = process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME!;
+export const AGENT_ID = process.env.NEXT_PUBLIC_ALGOLIA_AGENT_ID!;
+
+// Search-only lite client, shared by InstantSearch and the chat search UI.
+export const searchClient = liteClient(APP_ID, SEARCH_API_KEY);
+
+// Minimal product-hit shape. Adjust field names to match your index schema.
+export type ProductHit = {
+  objectID: string;
+  name?: string;
+  price?: number | string;
+  image?: string;
+  brand?: string;
+  // Per-query attribution token. InstantSearch stamps this on every hit it
+  // renders in the chat carousel; the itemComponent reads it to attribute
+  // click/conversion events back to the agent's search.
+  __queryID?: string;
+};

--- a/examples/coding-with-ai-nextjs/app/lib/cart.ts
+++ b/examples/coding-with-ai-nextjs/app/lib/cart.ts
@@ -1,0 +1,24 @@
+"use client";
+
+// MOCK cart. In-memory only — state is lost on refresh and is NOT shared with a
+// server. A real integration would POST to your commerce backend here. It exists
+// so the add_to_cart client-side tool has something concrete to call.
+
+export type CartLine = { productId: string; quantity: number };
+
+const lines: CartLine[] = [];
+
+export function addToCart(productId: string, quantity = 1): CartLine {
+  const existing = lines.find((l) => l.productId === productId);
+  if (existing) {
+    existing.quantity += quantity;
+    return existing;
+  }
+  const line: CartLine = { productId, quantity };
+  lines.push(line);
+  return line;
+}
+
+export function getCart(): CartLine[] {
+  return lines.map((l) => ({ ...l }));
+}

--- a/examples/coding-with-ai-nextjs/app/lib/insights.ts
+++ b/examples/coding-with-ai-nextjs/app/lib/insights.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { insightsClient } from "algoliasearch";
+import { APP_ID, SEARCH_API_KEY, INDEX_NAME } from "./algolia";
+
+// In algoliasearch v5, Insights is its own client (the search client has no
+// pushEvents). We reuse the same app ID + search key.
+const insights = insightsClient(APP_ID, SEARCH_API_KEY);
+
+// --------------------------------------------------------------------------
+// User token
+// --------------------------------------------------------------------------
+let authenticatedToken: string | null = null;
+
+/** Call on login/logout to switch between the user ID and the anon token. */
+export function setInsightsUserToken(userId: string | null): void {
+  authenticatedToken = userId;
+}
+
+function getOrCreateAnonToken(): string {
+  let token = localStorage.getItem("algolia_anon_token");
+  if (!token) {
+    token = `anon-${crypto.randomUUID()}`;
+    localStorage.setItem("algolia_anon_token", token);
+  }
+  return token;
+}
+
+function getUserToken(): string {
+  return authenticatedToken ?? getOrCreateAnonToken();
+}
+
+// --------------------------------------------------------------------------
+// Chat search attribution (the corrected pattern)
+// --------------------------------------------------------------------------
+//
+// The agent runs its searches server-side, so there is no client-side search to
+// read a queryID from. But InstantSearch stamps a per-query `__queryID` onto
+// every hit it renders in the chat carousel. So the queryID comes from THE HIT
+// ITSELF (`item.__queryID`), recorded by the chat `itemComponent` when the card
+// renders — see components/ChatWidget.tsx.
+//
+// This is why we do NOT key off a hardcoded tool name (the search tool is
+// renameable per agent — `algolia_search_index`, a custom name, or an
+// MCP-suffixed variant), and NOT off the assistant message's streamed `parts`:
+// the `assistantMessageFooterComponent` in this version of react-instantsearch
+// is typed `() => Element` and receives no props, so it cannot read the message
+// at all. The hit is the reliable, library-idiomatic source.
+//
+// Clicks go straight through InstantSearch's `sendEvent` helper in the
+// itemComponent (it derives queryID/position from the hit), so there is no click
+// tracker here. This module only needs to remember each hit's queryID + price so
+// the add-to-cart conversion (fired later, from the tool handler) can attribute
+// itself to the agent's search.
+
+// objectID -> { queryID, price } captured from the hits the agent surfaced.
+const queryIdByObjectID = new Map<string, { queryID?: string; price?: string }>();
+
+/** Record a hit's queryID + price so a later conversion can be attributed. */
+export function recordSearchHit(objectID: string, queryID?: string, price?: number | string): void {
+  queryIdByObjectID.set(objectID, {
+    queryID,
+    price: price != null ? String(price) : undefined,
+  });
+}
+
+/** Add-to-cart attributed to the agent's search (conversion-after-search). */
+export function trackChatAddToCart(objectID: string, quantity = 1): void {
+  const ctx = queryIdByObjectID.get(objectID);
+  const userToken = getUserToken();
+  // Prefer the price captured from the agent's search hits. A real store would
+  // resolve the authoritative price server-side; this keeps the event valid.
+  const price = ctx?.price ?? "0.00";
+
+  if (ctx?.queryID) {
+    // Conversion-after-search: attach the queryID. No `positions` needed for a
+    // conversion event.
+    void insights.pushEvents({
+      events: [
+        {
+          eventType: "conversion",
+          eventSubtype: "addToCart",
+          eventName: "Added to Cart from Chat",
+          index: INDEX_NAME,
+          userToken,
+          objectIDs: [objectID],
+          queryID: ctx.queryID,
+          objectData: [{ price, quantity, queryID: ctx.queryID }],
+          currency: "USD",
+        },
+      ],
+    });
+  } else {
+    // No queryID for this product (it was not surfaced by an agent search):
+    // record a plain, unattributed addToCart conversion.
+    void insights.pushEvents({
+      events: [
+        {
+          eventType: "conversion",
+          eventSubtype: "addToCart",
+          eventName: "Added to Cart from Chat",
+          index: INDEX_NAME,
+          userToken,
+          objectIDs: [objectID],
+          objectData: [{ price, quantity }],
+          currency: "USD",
+        },
+      ],
+    });
+  }
+}

--- a/examples/coding-with-ai-nextjs/app/page.tsx
+++ b/examples/coding-with-ai-nextjs/app/page.tsx
@@ -1,0 +1,23 @@
+import { Providers } from "./providers";
+import { Search } from "./components/Search";
+import { ChatWidget } from "./components/ChatWidget";
+
+// Server Component. It composes the client provider and client UI — a Server
+// Component may render Client Components, but the Algolia/chat pieces themselves
+// must be Client Components ("use client"), because the streaming Chat widget and
+// InstantSearch hooks are browser-only.
+export default function Home() {
+  return (
+    <Providers>
+      <main className="page">
+        <header className="page-header">
+          <h1>Coding with AI</h1>
+          <p>Algolia search plus an Agent Studio shopping assistant.</p>
+        </header>
+        <Search />
+      </main>
+      {/* The floating chat widget renders its own toggle button. */}
+      <ChatWidget />
+    </Providers>
+  );
+}

--- a/examples/coding-with-ai-nextjs/app/providers.tsx
+++ b/examples/coding-with-ai-nextjs/app/providers.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { InstantSearchNext } from "react-instantsearch-nextjs";
+import { searchClient, INDEX_NAME } from "./lib/algolia";
+
+// SSR-safe InstantSearch provider for the App Router. Use <InstantSearchNext>
+// from react-instantsearch-nextjs — NOT the plain <InstantSearch> — so search
+// state hydrates correctly on the server. Everything Algolia-related lives below
+// this provider and is a Client Component.
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <InstantSearchNext
+      searchClient={searchClient}
+      indexName={INDEX_NAME}
+      routing={true}
+      future={{ preserveSharedStateOnUnmount: true }}
+    >
+      {children}
+    </InstantSearchNext>
+  );
+}

--- a/examples/coding-with-ai-nextjs/next-env.d.ts
+++ b/examples/coding-with-ai-nextjs/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/coding-with-ai-nextjs/next.config.mjs
+++ b/examples/coding-with-ai-nextjs/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/examples/coding-with-ai-nextjs/package-lock.json
+++ b/examples/coding-with-ai-nextjs/package-lock.json
@@ -1,0 +1,1318 @@
+{
+  "name": "coding-with-ai-nextjs",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "coding-with-ai-nextjs",
+      "version": "0.1.0",
+      "dependencies": {
+        "algoliasearch": "^5.56.0",
+        "instantsearch.css": "^8.18.0",
+        "jsonwebtoken": "^9.0.2",
+        "next": "^14.2.15",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-instantsearch": "^7.40.0",
+        "react-instantsearch-nextjs": "^1.3.0"
+      },
+      "devDependencies": {
+        "@types/jsonwebtoken": "^9.0.7",
+        "@types/node": "^20.17.0",
+        "@types/react": "^18.3.18",
+        "@types/react-dom": "^18.3.5",
+        "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
+      "integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
+      "integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
+      "integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
+      "integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
+      "integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
+      "integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
+      "integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
+      "integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/events": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
+      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
+      "integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
+      "integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
+      "integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
+      "integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
+      "integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
+      "integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ=="
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/dom-speech-recognition": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dom-speech-recognition/-/dom-speech-recognition-0.0.1.tgz",
+      "integrity": "sha512-udCxb8DvjcDKfk1WTBzDsxFbLgYxmQGKrE/ricoMqHRNjSlSUCcamVTA5lIQqzY10mY5qCY0QDwBfFEwhfoDPw=="
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.65.3",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.65.3.tgz",
+      "integrity": "sha512-tqbbx7MUtoDk+RwpZMymPDj6Skez0FhqDZNhLhS5UDmCx4D1dgP+BJOHTebiO/rhjJLa1f8te2p6mJJeFKVFOQ=="
+    },
+    "node_modules/@types/hogan.js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hogan.js/-/hogan.js-3.0.5.tgz",
+      "integrity": "sha512-/uRaY3HGPWyLqOyhgvW9Aa43BNnLZrNeQxl2p8wqId4UHMfPKolSB+U7BlZyO1ng7MkLnyEAItsBzCG0SDhqrA=="
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
+      "integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
+      "dependencies": {
+        "@algolia/abtesting": "1.22.0",
+        "@algolia/client-abtesting": "5.56.0",
+        "@algolia/client-analytics": "5.56.0",
+        "@algolia/client-common": "5.56.0",
+        "@algolia/client-insights": "5.56.0",
+        "@algolia/client-personalization": "5.56.0",
+        "@algolia/client-query-suggestions": "5.56.0",
+        "@algolia/client-search": "5.56.0",
+        "@algolia/ingestion": "1.56.0",
+        "@algolia/monitoring": "1.56.0",
+        "@algolia/recommend": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/algoliasearch-helper": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.2.tgz",
+      "integrity": "sha512-SaV+rZM3drExb0punEYYjT+sNcH74YFwN8ocjya7IDOyQvKWeQpEaSMVG3+IGTVos+feuatj7ljQ4BXlXdUp3w==",
+      "dependencies": {
+        "@algolia/events": "^4.0.1"
+      },
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 6"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hogan.js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+      "integrity": "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==",
+      "dependencies": {
+        "mkdirp": "0.3.0",
+        "nopt": "1.0.10"
+      },
+      "bin": {
+        "hulk": "bin/hulk"
+      }
+    },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
+    },
+    "node_modules/instantsearch-ui-components": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.33.1.tgz",
+      "integrity": "sha512-ZN25FlLwXx0UChsQtEwDuPQDTQXx3ztC2+Js0d/ztCgn/045WY1lrpccOoXccZFvo3rsW2ug4T1MdN+7g1TYeQ==",
+      "dependencies": {
+        "@swc/helpers": "0.5.18",
+        "markdown-to-jsx": "^7.7.15"
+      }
+    },
+    "node_modules/instantsearch-ui-components/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/instantsearch.css": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/instantsearch.css/-/instantsearch.css-8.18.0.tgz",
+      "integrity": "sha512-7/WWu9fpPzQi5Z7Z//Lf9V4gmFU3TazneJkm7fJSApICOjLHhc3C65O84CilV+rkNIIaGuc9Kn5G1fHo3A08jQ==",
+      "dependencies": {
+        "tweakpane": "4.0.5"
+      }
+    },
+    "node_modules/instantsearch.js": {
+      "version": "4.107.0",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.107.0.tgz",
+      "integrity": "sha512-xXQGI3dOqseKtYi4NtUthv8Zc9MD0oaYnGdP8r5O1MtJ0MF+9yr1pZ5380fP+xitKqwvGCghnkeP5m03aqLXBQ==",
+      "dependencies": {
+        "@algolia/events": "^4.0.1",
+        "@swc/helpers": "0.5.18",
+        "@types/dom-speech-recognition": "^0.0.1",
+        "@types/google.maps": "^3.55.12",
+        "@types/hogan.js": "^3.0.0",
+        "@types/qs": "^6.5.3",
+        "algoliasearch-helper": "3.29.2",
+        "hogan.js": "^3.0.2",
+        "htm": "^3.0.0",
+        "instantsearch-ui-components": "0.33.1",
+        "preact": "^10.10.0",
+        "qs": "^6.5.1",
+        "react": ">= 0.14.0",
+        "search-insights": "^2.17.2"
+      },
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 6"
+      }
+    },
+    "node_modules/instantsearch.js/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "7.7.17",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.17.tgz",
+      "integrity": "sha512-7mG/1feQ0TX5I7YyMZVDgCC/y2I3CiEhIRQIhyov9nGBP5eoVrOXXHuL5ZP8GRfxVZKRiXWJgwXkb9It+nQZfQ==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "dependencies": {
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-instantsearch": {
+      "version": "7.40.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch/-/react-instantsearch-7.40.0.tgz",
+      "integrity": "sha512-uI1SMkSwd+vo1myM4KvEDAptLIBM6mqtg9uezTn8WsOiq8sY2JJuy1mDn1yOHZBc0ACG2qRTesAFx+yNwCiEZA==",
+      "dependencies": {
+        "@swc/helpers": "0.5.18",
+        "instantsearch-ui-components": "0.33.1",
+        "instantsearch.js": "4.107.0",
+        "react-instantsearch-core": "7.40.0"
+      },
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 6",
+        "react": ">= 16.8.0 < 20",
+        "react-dom": ">= 16.8.0 < 20"
+      }
+    },
+    "node_modules/react-instantsearch-core": {
+      "version": "7.40.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-7.40.0.tgz",
+      "integrity": "sha512-hctSltVTQD9fmyM6OSNxdxnNjHSAVpNohSy/mGwZ/3F4Jjj3Z3fT5v8qTdYsWi9cXOPP+r1Szyom5/TtdtwQiQ==",
+      "dependencies": {
+        "@swc/helpers": "0.5.18",
+        "algoliasearch-helper": "3.29.2",
+        "instantsearch.js": "4.107.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 6",
+        "react": ">= 16.8.0 < 20"
+      }
+    },
+    "node_modules/react-instantsearch-core/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/react-instantsearch-nextjs": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-nextjs/-/react-instantsearch-nextjs-1.3.0.tgz",
+      "integrity": "sha512-zqQdH6joZkoGLWxWASZFX7LCShPaSEw9I7XiBJuScrLmUMja2TfByay62i8W3v4NTGU+L+oXw/RimwP9+bKJFA==",
+      "dependencies": {
+        "@swc/helpers": "0.5.18"
+      },
+      "peerDependencies": {
+        "next": ">= 13.4 < 17",
+        "react-instantsearch": ">= 7.1.0 < 8"
+      }
+    },
+    "node_modules/react-instantsearch-nextjs/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/react-instantsearch/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tweakpane": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-4.0.5.tgz",
+      "integrity": "sha512-rxEXdSI+ArlG1RyO6FghC4ZUX8JkEfz8F3v1JuteXSV0pEtHJzyo07fcDG+NsJfN5L39kSbCYbB9cBGHyuI/tQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/cocopon"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    }
+  }
+}

--- a/examples/coding-with-ai-nextjs/package.json
+++ b/examples/coding-with-ai-nextjs/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "coding-with-ai-nextjs",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Reference app: Algolia InstantSearch + an Agent Studio chat agent on the Next.js App Router.",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "algoliasearch": "^5.56.0",
+    "instantsearch.css": "^8.18.0",
+    "jsonwebtoken": "^9.0.2",
+    "next": "^14.2.15",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-instantsearch": "^7.40.0",
+    "react-instantsearch-nextjs": "^1.3.0"
+  },
+  "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.7",
+    "@types/node": "^20.17.0",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "typescript": "^5.7.3"
+  }
+}

--- a/examples/coding-with-ai-nextjs/tsconfig.json
+++ b/examples/coding-with-ai-nextjs/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/skills/agent-studio/SKILL.md
+++ b/skills/agent-studio/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: agent-studio
+description: |
+  Build agentic chat experiences with Algolia Agent Studio and the react-instantsearch Chat widget. Use this skill whenever the user wants to: integrate Agent Studio into a React app, add a chat widget, create client-side tools for the chat agent, customize the chat UI/CSS, send Algolia Insights events, implement user authentication with secure tokens, set up memory/personalization, inject context into chat conversations, create prompt starters, or build any AI-powered conversational shopping/search experience with Algolia. Also use when the user mentions Agent Studio, InstantSearch Chat, or asks about connecting an LLM to Algolia search data.
+---
+
+# Agent Studio Integration Skill
+
+This skill guides you through building agentic chat experiences using Algolia
+Agent Studio with the `react-instantsearch` Chat component.
+
+Long code samples and any topic-specific detail live in `references/`. Each
+section below links to its reference file. When you need deeper detail, read
+the linked reference.
+
+## Official Documentation
+
+- Agent Studio Guide: https://www.algolia.com/doc/guides/algolia-ai/agent-studio
+- Agent Studio API Reference: https://www.algolia.com/doc/rest-api/agent-studio
+- Chat Widget (React): https://www.algolia.com/doc/api-reference/widgets/chat/react
+- Client-Side Tools: https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/tools/client-side-tools
+- Memory: https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/memory/overview
+- User Authentication: https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/user-authentication
+- Integration Guide: https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/integration
+- Full docs index: https://algolia.com/doc/llms.txt
+
+When you need deeper detail on any topic, fetch the relevant URL above.
+
+## Architecture Overview
+
+An Agent Studio integration has these layers:
+
+```text
+React App
+├── InstantSearch provider (wraps everything)
+│   └── <Chat> component (the widget)
+│       ├── transport (API endpoint + auth headers)
+│       ├── tools (client-side tool handlers)
+│       ├── itemComponent (renders product cards in chat)
+│       └── suggestionsComponent (renders suggestion chips)
+├── ChatContext (open/close state, context injection)
+├── Algolia Insights (event tracking)
+└── Memory Channel (personalization via background messages)
+
+Server
+├── Auth endpoints (JWT tokens)
+├── Algolia secure token generation (for user-scoped memory/conversations)
+└── Business logic endpoints (orders, cart, etc.)
+```
+
+## 1. Basic Setup
+
+### Dependencies
+
+```bash
+npm install react-instantsearch algoliasearch instantsearch.css
+```
+
+### Environment Variables
+
+Client-side:
+
+```text
+VITE_ALGOLIA_APP_ID=<your-app-id>
+VITE_ALGOLIA_SEARCH_API_KEY=<your-search-api-key>
+VITE_ALGOLIA_AGENT_ID=<your-agent-id>
+VITE_ALGOLIA_INDEX_NAME=products
+```
+
+Server-side (for authenticated features):
+
+```text
+ALGOLIA_SECRET_KEY=sk-alg-...  # From Agent Studio Settings > Authentication
+ALGOLIA_KEY_ID=<key-id>        # From the same page
+```
+
+### Minimal Chat Integration
+
+```tsx
+import { liteClient as algoliasearch } from "algoliasearch/lite";
+import { InstantSearch, Chat } from "react-instantsearch";
+import "instantsearch.css/components/chat.css";
+
+const searchClient = algoliasearch(appId, apiKey);
+
+function App() {
+  return (
+    <InstantSearch searchClient={searchClient} indexName="products">
+      <Chat agentId={agentId} />
+    </InstantSearch>
+  );
+}
+```
+
+The `agentId` prop is the simplest way to connect. For custom headers (auth
+tokens, etc.), use the `transport` prop instead.
+
+### Custom Transport (required for authenticated users)
+
+```tsx
+<Chat
+  transport={{
+    api: `https://${appId}.algolia.net/agent-studio/1/agents/${agentId}/completions?compatibilityMode=ai-sdk-5`,
+    headers: async () => ({
+      "x-algolia-application-id": appId,
+      "x-algolia-api-Key": apiKey,
+      // Optional, for memory/personalization:
+      "X-Algolia-Secure-User-Token": await fetchAlgoliaToken(),
+    }),
+  }}
+/>
+```
+
+The `compatibilityMode=ai-sdk-5` query parameter is REQUIRED when using the
+transport prop. The `X-Algolia-Secure-User-Token` header carries the JWT that
+scopes memory and conversations to a user (see section 6).
+
+## 2. Client-Side Tools
+
+Client-side tools let the agent trigger actions in your frontend (fetch user
+data, update UI, add to cart, etc.). They follow the OpenAI Function Calling
+spec: define the schema in the Agent Studio dashboard under
+**Tools > Client-side tools**, and register a handler on `<Chat>`.
+
+### The layoutComponent pattern (IMPORTANT)
+
+Use `layoutComponent` (NOT `onToolCall`) for async client-side tools. The
+`onToolCall` callback runs during the library's stream-processing phase, which
+can deadlock the internal `SerialJobExecutor` with async work.
+`layoutComponent` defers execution to React's render cycle and avoids it.
+
+```tsx
+function MyToolHandler({ message, addToolResult }) {
+  const fetchedRef = useRef(false);
+  useEffect(() => {
+    if (message.state !== "input-available" || fetchedRef.current) return;
+    fetchedRef.current = true;
+    fetchSomeData()
+      .then((data) => addToolResult({ output: data }))
+      .catch((err) => addToolResult({ output: { error: err.message } }));
+  }, [message.state, addToolResult]);
+  return <></>; // Render UI, or empty fragment for invisible tools
+}
+
+<Chat tools={{ my_tool_name: { layoutComponent: MyToolHandler } }} />;
+```
+
+Key rules:
+
+- Check `message.state === "input-available"` before executing.
+- Use `useRef` to prevent duplicate executions.
+- Always call `addToolResult` (even on error) so the agent can continue.
+- Tool keys must match the tool name configured in Agent Studio.
+- In production, set `"strict": true` on the tool schema; then ALL properties
+  must be in `required`, and optional fields use the union type
+  `["type", "null"]`.
+
+Full handler typing and the tool-definition JSON schemas (with and without
+parameters) are in [references/client-side-tools.md](references/client-side-tools.md).
+
+## 3. Custom Components
+
+The Chat component accepts render-prop components for product cards
+(`itemComponent`), suggestion chips (`suggestionsComponent`), header/footer
+icons, message wrappers, and more. Use the built-in class names (for example
+`ais-ChatPromptSuggestions-suggestion`) so default styles and your overrides
+apply.
+
+Minimal product card:
+
+```tsx
+<Chat
+  itemComponent={({ item }) => (
+    <a href={`/product/${item.objectID}`}>
+      <img src={item.image} alt={item.name} />
+      <p>{item.name}</p>
+      <span>${item.price}</span>
+    </a>
+  )}
+/>
+```
+
+The item component receives Algolia hit objects; field names follow your index
+schema (`objectID`, `name`/`title`, `price`, `image`, `brand`, `category`).
+
+Full component list, the suggestions component, and translations
+(`textareaPlaceholder`, `disclaimer`, header `title`, etc.) are in
+[references/components-and-css.md](references/components-and-css.md).
+
+## 4. CSS Customization
+
+Import the base styles, then override with CSS custom properties (design
+tokens) and class selectors:
+
+```css
+@import "instantsearch.css/components/chat.css";
+
+.ais-Chat {
+  --ais-primary-color-rgb: 0, 0, 0;           /* Brand color (RGB) */
+  --ais-text-color-rgb: 26, 28, 29;           /* Main text */
+  --ais-background-color-rgb: 255, 255, 255;  /* Background */
+  --ais-font-family: "Inter", system-ui, sans-serif;
+}
+```
+
+Key class names include `.ais-Chat` (root), `.ais-Chat-container--open` (open
+state), `.ais-ChatToggleButton`, `.ais-ChatMessage--user` /
+`.ais-ChatMessage--assistant`, `.ais-ChatPrompt-textarea`, and
+`.ais-ChatToolSearchIndexCarousel-item` (product cards).
+
+The full class-name table, design-token list, mobile bottom-sheet pattern, and
+product-carousel styling are in [references/components-and-css.md](references/components-and-css.md).
+A complete monochrome override file is in [references/css-overrides-example.md](references/css-overrides-example.md).
+
+## 5. Context Injection
+
+Context injection sends hidden system context to the agent (for example "user
+is on product page X") without the user seeing it.
+
+Pattern:
+
+1. Format messages as a `[Context: {system info}]{visible user message}` string.
+2. Inject the string into the Chat textarea using the native
+   `HTMLTextAreaElement` value setter (so React's `onChange` fires), then submit
+   the form programmatically. If the chat is closed, open it first.
+3. Strip the `[Context: ...]` prefix from the DOM before the user sees it: a
+   `MutationObserver` plus polling scans user message elements, matches their
+   text against a context pattern, and either hides context-only messages or
+   replaces the text with just the visible portion.
+
+A `sendWithContext(context, visibleMessage?)` action (exposed via a
+`ChatContext` provider) builds the string, injects, and submits. Use it to
+auto-inject product context when the chat opens on a product page, or to power
+prompt starters that carry context while showing the user only a question.
+
+The full `ChatProvider`, the `useContextStripping()` hook (including the context
+regex and DOM-matching logic), the provider hierarchy, and usage examples are in
+[references/context-injection.md](references/context-injection.md).
+
+## 6. User Authentication & Secure Tokens
+
+Memory and conversation scoping require user authentication via JWT tokens. Mint
+the token server-side (so the Agent Studio secret never reaches the browser) and
+pass it to the Chat transport as the `X-Algolia-Secure-User-Token` header.
+
+- Server: sign an HS256 JWT with `sub = userId`, `expiresIn`, and a header `kid`
+  equal to your Key ID. The secret (`sk-alg-...`) and Key ID come from Agent
+  Studio **Settings > Authentication**.
+- Client: cache the token, refresh it before `exp`, and fall back to `null` for
+  anonymous users. Read it in the transport `headers` callback.
+- Account switching: on logout/switch, clear session storage keys prefixed with
+  `instantsearch-chat-initial-messages`, and re-key `<InstantSearch>` with
+  `key={user?.id ?? "anon"}` so the chat remounts with a fresh session.
+
+Full server and client token code and the account-switching snippet are in
+[references/authentication.md](references/authentication.md).
+
+## 7. Memory & Personalization
+
+Memory lets the agent remember facts about users across conversations.
+
+- Enable it in the dashboard: **Customizations > Memory**, with data retention
+  set to 30/60/90 days (NOT 0), and require user authentication (section 6).
+- Memory types: **semantic** (stable user facts/preferences) and **episodic**
+  (agent reasoning chains).
+- When enabled, three tools are auto-added: `algolia_memorize` (semantic),
+  `algolia_ponder` (episodic), and `algolia_memory_search`.
+- Memory channel pattern: send background context to the agent by firing a
+  completion request whose message is prefixed with `[MEMORY]`, then consume and
+  discard the response body. Fire it on product views, add-to-cart, and
+  purchases.
+- Include a memory instruction in the agent's system prompt so it extracts
+  facts from `[Context:...]` messages for future personalization.
+
+The full memory-channel `fetch` implementation, the event triggers, and the
+memory system-prompt block are in [references/memory.md](references/memory.md).
+
+## 8. Algolia Insights Events
+
+Track user behavior to power Algolia analytics and AI Personalization. Send
+events with the lite client's `pushEvents` method.
+
+- Setup: `algoliasearch(appId, apiKey)` from `algoliasearch/lite`.
+- User token: stable random `anon-...` token in localStorage for anonymous
+  users; switch to the authenticated user ID on login.
+- Event shapes:
+  - View: `eventType: "view"`, `objectIDs`.
+  - Click after search: `eventType: "click"` with `positions` (1-based) and the
+    search response's `queryID`.
+  - Add to cart: `eventType: "conversion"`, `eventSubtype: "addToCart"`, with
+    `objectData` (`price`, `quantity`) and `currency`.
+  - Purchase: `eventType: "conversion"`, `eventSubtype: "purchase"`, with
+    per-item `objectData` and `currency`.
+- Search-context attribution: on a search-result click, store `queryID` +
+  `position` in sessionStorage keyed by `objectID`; consume it on the product
+  page to attribute later clicks/conversions to the originating query.
+
+Full event payloads, the user-token helpers, and the attribution
+store/consume helpers are in [references/insights-events.md](references/insights-events.md).
+
+## 9. Prompt Starters
+
+Generate personalized conversation starters on product pages using a separate
+agent:
+
+1. Create a dedicated Agent Studio agent for prompt generation.
+2. Call the agent API directly with product context and a
+   `display_prompt_starters` tool.
+3. Parse the streamed response for tool-call arguments.
+4. Render the starters as clickable buttons that inject context into the main
+   chat (via `sendWithContext`, section 5).
+
+The full prompt-starters component with streaming-response parsing is in
+[references/prompt-starters.md](references/prompt-starters.md).
+
+## 10. Agent Prompt Best Practices
+
+When writing the agent's system prompt in Agent Studio:
+
+- **Search strategy**: use short keywords, not natural language. Use facet
+  filters only for exact categorical matches (brand, category). Never use facet
+  filters for price — search without them and post-filter.
+- **Tool results**: don't summarize products returned by search — they're
+  already displayed as cards. Just give brief context ("I found 5 laptops
+  matching your criteria").
+- **Personalization flow**: when the user references past purchases, call
+  `get_user_orders` FIRST before searching.
+- **Memory**: instruct the agent to extract context from `[Context:...]`
+  messages for future personalization.
+- **Limits**: set a max number of search calls per session (e.g. 5) to control
+  costs.
+- **Error handling**: on tool errors, apologize once and invite the user to
+  rephrase.
+
+A complete example agent system prompt is in
+[references/agent-prompt-example.md](references/agent-prompt-example.md).
+
+## Reference Files
+
+For detailed implementation examples beyond this guide, read the reference files
+in this skill's `references/` directory:
+
+- [references/client-side-tools.md](references/client-side-tools.md) — full
+  tool handler typing and tool-definition JSON schemas
+- [references/components-and-css.md](references/components-and-css.md) — full
+  component list, translations, CSS class-name table, design tokens, and
+  customization patterns
+- [references/css-overrides-example.md](references/css-overrides-example.md) —
+  complete CSS override file for a monochrome design system
+- [references/context-injection.md](references/context-injection.md) — full
+  ChatContext provider and useContextStripping implementations
+- [references/authentication.md](references/authentication.md) — server/client
+  secure-token code and account-switching cleanup
+- [references/memory.md](references/memory.md) — memory-channel fetch
+  implementation and memory system-prompt block
+- [references/insights-events.md](references/insights-events.md) — full Insights
+  event payloads and search attribution helpers
+- [references/prompt-starters.md](references/prompt-starters.md) — prompt
+  starters component with streaming response parsing
+- [references/agent-prompt-example.md](references/agent-prompt-example.md) —
+  complete agent system prompt template

--- a/skills/agent-studio/SKILL.md
+++ b/skills/agent-studio/SKILL.md
@@ -48,6 +48,20 @@ Server
 └── Business logic endpoints (orders, cart, etc.)
 ```
 
+## Framework notes
+
+The examples target a **client-rendered React app** (Vite/CRA): they use
+`import.meta.env`/`VITE_*`, `sessionStorage`, browser-only DOM APIs
+(`MutationObserver`, `document.querySelector`), and `<BrowserRouter>`. They do
+not run as-is on the Next.js App Router. For Next.js:
+
+- Mark chat components with `"use client"`.
+- Use `NEXT_PUBLIC_*` env vars instead of `import.meta.env`.
+- Use `<InstantSearchNext>` from `react-instantsearch-nextjs` (per Algolia's
+  InstantSearch SSR guidance) instead of `<InstantSearch>`.
+- SSR support for the streaming `<Chat>` widget is limited — render it
+  client-side.
+
 ## 1. Basic Setup
 
 ### Dependencies
@@ -294,10 +308,14 @@ events with the lite client's `pushEvents` method.
 - Search-context attribution: on a search-result click, store `queryID` +
   `position` in sessionStorage keyed by `objectID`; consume it on the product
   page to attribute later clicks/conversions to the originating query.
-- Attribute chat events to the agent's search: the `algolia_search` tool result
-  streamed to the client includes the `queryID` of the agent's server-side
-  search (run with click analytics and tagged `alg#agent-studio`). Build an
-  `objectID → { queryID, position }` map from the streamed search results and
+- Attribute chat events to the agent's search: the agent's server-side search
+  tool result (run with click analytics and tagged `alg#agent-studio`) is
+  streamed to the client and carries the `queryID` alongside its `hits`. Do not
+  filter by a hardcoded tool name — the search tool's type and default name is
+  `algolia_search_index`, but it is configurable per tool (custom names, or
+  MCP-suffixed like `algolia_search_index_products`). Instead iterate all
+  streamed tool result parts and key off any part that has both a `queryID` and
+  `hits`. Build an `objectID → { queryID, position }` map from those results and
   include that `queryID` (and `positions` for clicks) in click and conversion
   events for products the agent surfaced. Otherwise those clicks and conversions
   are not attributed to the agent's searches, and its click-through, conversion,

--- a/skills/agent-studio/SKILL.md
+++ b/skills/agent-studio/SKILL.md
@@ -294,9 +294,17 @@ events with the lite client's `pushEvents` method.
 - Search-context attribution: on a search-result click, store `queryID` +
   `position` in sessionStorage keyed by `objectID`; consume it on the product
   page to attribute later clicks/conversions to the originating query.
+- Attribute chat events to the agent's search: the `algolia_search` tool result
+  streamed to the client includes the `queryID` of the agent's server-side
+  search (run with click analytics and tagged `alg#agent-studio`). Build an
+  `objectID → { queryID, position }` map from the streamed search results and
+  include that `queryID` (and `positions` for clicks) in click and conversion
+  events for products the agent surfaced. Otherwise those clicks and conversions
+  are not attributed to the agent's searches, and its click-through, conversion,
+  and revenue analytics are lost.
 
-Full event payloads, the user-token helpers, and the attribution
-store/consume helpers are in [references/insights-events.md](references/insights-events.md).
+Full event payloads, the user-token helpers, the chat-attribution helpers, and
+the search-context store/consume helpers are in [references/insights-events.md](references/insights-events.md).
 
 ## 9. Prompt Starters
 

--- a/skills/agent-studio/SKILL.md
+++ b/skills/agent-studio/SKILL.md
@@ -308,18 +308,25 @@ events with the lite client's `pushEvents` method.
 - Search-context attribution: on a search-result click, store `queryID` +
   `position` in sessionStorage keyed by `objectID`; consume it on the product
   page to attribute later clicks/conversions to the originating query.
-- Attribute chat events to the agent's search: the agent's server-side search
-  tool result (run with click analytics and tagged `alg#agent-studio`) is
-  streamed to the client and carries the `queryID` alongside its `hits`. Do not
-  filter by a hardcoded tool name — the search tool's type and default name is
-  `algolia_search_index`, but it is configurable per tool (custom names, or
-  MCP-suffixed like `algolia_search_index_products`). Instead iterate all
-  streamed tool result parts and key off any part that has both a `queryID` and
-  `hits`. Build an `objectID → { queryID, position }` map from those results and
-  include that `queryID` (and `positions` for clicks) in click and conversion
-  events for products the agent surfaced. Otherwise those clicks and conversions
-  are not attributed to the agent's searches, and its click-through, conversion,
-  and revenue analytics are lost.
+- Attribute chat events to the agent's search: the agent searches server-side,
+  but `react-instantsearch` stamps the `queryID` onto each hit as
+  `item.__queryID`. The chat's `itemComponent` receives the hit (`item`) and a
+  built-in `sendEvent` helper, so the queryID comes from the hit — do NOT read
+  the assistant message's streamed `parts` and do NOT match on a tool name (the
+  search tool is renameable per agent, and the chat's message-footer component
+  receives no message in this library version, so it cannot read the results).
+  - Clicks: fire `sendEvent("click", item, "…")` in the `itemComponent`;
+    InstantSearch derives the `queryID` and position from the hit (no manual
+    `pushEvents`).
+  - Conversions (add-to-cart/purchase): triggered by a client-side tool, not a
+    hit click, so they cannot use `sendEvent`. Record
+    `objectID → { queryID, price }` as cards render, then look it up on the
+    conversion and send a conversion-after-search event carrying that `queryID`
+    (in `objectData` with `price`/`quantity`; no `positions` needed).
+  - Agent Studio runs these searches with click analytics and tags them
+    `alg#agent-studio`. Without the `queryID`, events are still recorded but do
+    not count as click- or conversion-after-search, so the agent's
+    click-through, conversion, and revenue analytics are lost.
 
 Full event payloads, the user-token helpers, the chat-attribution helpers, and
 the search-context store/consume helpers are in [references/insights-events.md](references/insights-events.md).

--- a/skills/agent-studio/evals/evals.json
+++ b/skills/agent-studio/evals/evals.json
@@ -1,0 +1,44 @@
+{
+  "skill_name": "agent-studio",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I have a React storefront and an Agent Studio agent. Add a chat widget to my site so shoppers can talk to the agent.",
+      "expected_output": "Install react-instantsearch, wrap the app in InstantSearch, and render the Chat widget wired to the agent.",
+      "files": [],
+      "expectations": [
+        "Installs react-instantsearch, algoliasearch, and instantsearch.css",
+        "Wraps the app in an <InstantSearch> provider with a search client and index name",
+        "Renders the <Chat> component, connecting it with the agentId prop for the simple case",
+        "For authenticated headers, uses the transport prop and includes compatibilityMode=ai-sdk-5 in the completions URL",
+        "Imports the chat CSS (instantsearch.css/components/chat.css)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "My Agent Studio chat agent needs to fetch the logged-in user's order history from my backend when it asks for it. Wire up that client-side tool.",
+      "expected_output": "Define the tool in Agent Studio, then handle it on the client with the layoutComponent pattern.",
+      "files": [],
+      "expectations": [
+        "Registers the tool on the <Chat> component under the tools prop, keyed by the tool name configured in Agent Studio",
+        "Uses the layoutComponent pattern rather than onToolCall for async work, and explains it avoids the SerialJobExecutor deadlock",
+        "Guards execution on message.state === 'input-available' and uses a useRef to prevent duplicate calls",
+        "Always calls addToolResult (including on error) so the agent can continue",
+        "Defines the matching function tool schema in the Agent Studio dashboard (with strict mode for production)"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Add analytics to my Algolia chat experience: track add-to-cart as a conversion with revenue, and make memory work for signed-in users.",
+      "expected_output": "Send Algolia Insights conversion events and pass a secure user token for user-scoped memory.",
+      "files": [],
+      "expectations": [
+        "Sends an Algolia Insights conversion event with eventSubtype 'addToCart', objectData (price/quantity), and a currency",
+        "Manages a stable userToken (anonymous token in localStorage, authenticated user id after login)",
+        "Generates a server-side JWT signed with the Agent Studio secret key, including the kid header",
+        "Passes the token to the Chat transport as the X-Algolia-Secure-User-Token header",
+        "Notes that memory requires user authentication and a non-zero data-retention setting in the dashboard"
+      ]
+    }
+  ]
+}

--- a/skills/agent-studio/evals/evals.json
+++ b/skills/agent-studio/evals/evals.json
@@ -43,10 +43,10 @@
     {
       "id": 4,
       "prompt": "Make sure clicks and add-to-cart from my Agent Studio chat are attributed to the agent's searches in Algolia analytics.",
-      "expected_output": "Read the queryID from the agent's algolia_search tool result and include it in click-after-search and conversion-after-search Insights events.",
+      "expected_output": "Read the queryID from the streamed search tool result (iterate the tool result parts, keying off parts that carry both queryID and hits rather than a hardcoded tool name) and include it in click-after-search and conversion-after-search Insights events.",
       "files": [],
       "expectations": [
-        "Explains that the chat agent searches server-side and the queryID is returned in the algolia_search tool result streamed to the client, not from a client-side search",
+        "Explains that the chat agent searches server-side and the queryID is returned in the streamed search tool result (iterate the tool result parts, keying off queryID + hits rather than a hardcoded tool name), not from a client-side search",
         "Builds a mapping from objectID to { queryID, position } from the streamed search tool results",
         "Sends click events with the queryID and 1-based positions (click-after-search) for products the agent surfaced",
         "Sends addToCart or purchase conversion events with the same queryID (conversion-after-search) rather than plain conversions",

--- a/skills/agent-studio/evals/evals.json
+++ b/skills/agent-studio/evals/evals.json
@@ -39,6 +39,19 @@
         "Passes the token to the Chat transport as the X-Algolia-Secure-User-Token header",
         "Notes that memory requires user authentication and a non-zero data-retention setting in the dashboard"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Make sure clicks and add-to-cart from my Agent Studio chat are attributed to the agent's searches in Algolia analytics.",
+      "expected_output": "Read the queryID from the agent's algolia_search tool result and include it in click-after-search and conversion-after-search Insights events.",
+      "files": [],
+      "expectations": [
+        "Explains that the chat agent searches server-side and the queryID is returned in the algolia_search tool result streamed to the client, not from a client-side search",
+        "Builds a mapping from objectID to { queryID, position } from the streamed search tool results",
+        "Sends click events with the queryID and 1-based positions (click-after-search) for products the agent surfaced",
+        "Sends addToCart or purchase conversion events with the same queryID (conversion-after-search) rather than plain conversions",
+        "Notes that without the queryID the events are not attributed to the agent's searches, losing click-through, conversion, and revenue analytics"
+      ]
     }
   ]
 }

--- a/skills/agent-studio/references/agent-prompt-example.md
+++ b/skills/agent-studio/references/agent-prompt-example.md
@@ -1,0 +1,74 @@
+# Agent Prompt Template
+
+Copy this into the agent's **System Prompt** field in Agent Studio. Replace `{{PLACEHOLDERS}}` with your values.
+
+```
+**AGENT ROLE**
+You are the {{INSERT_BRAND}} Shopping Assistant. Your goals are to help users find products via Algolia search, assist with order-related questions, and deliver personalized recommendations based on purchase history. Only answer questions about products in the catalog and in {{INSERT_INDUSTRY}}. If a user requests an item outside these indices, explain that it is not available in the catalog.
+
+**GUIDELINES**
+Language: reply in {{INSERT_LANGUAGE}} fallback to English.
+If available, provide links to the product pages.
+Tone: business-casual, respectful, never rigid ("sir/ma'am").
+Results: return at most 5 ProductCards.
+Clarifying Qs: ask up to 2 follow-up questions if confidence < 95%.
+SearchLimit: max {{5}} search_tool calls per session.
+Prohibited: hateful or hurtful content, any mention of competitors {{INSERT_COMPETITORS_LIST}}.
+ContentPolicy: comply with platform policy at all times.
+Pricing: NEVER mention discounts, sales, percentage-off deals, or promotions unless the product data explicitly contains a discount field. Only state the exact price shown in the product data. Inventing or implying discounts is strictly prohibited.
+If no hits after the final permitted search_tool call, reply: "Sorry, I couldn't find any matching items."
+On timeout or tool error, apologize once and invite user to rephrase.
+On competitor query, respond: "I'm afraid I can't help with that."
+On reaching the SearchLimit without success, send the same "couldn't find" message and stop further searches.
+
+**SEARCH STRATEGY**
+- Keep queries simple: use short keywords (e.g. "DKNY bag"), not natural language (e.g. "DKNY bag under 200").
+- Facet filters are for EXACT categorical matches (brand, category, color). NEVER use facet filters for price ranges or numeric conditions.
+- The search tool does NOT support price range filtering. When a user asks for products under/over/around a price, search WITHOUT price filters and return only the results that match the price condition.
+- Filter by brand and category facets when mentioned, but leave price filtering to post-processing.
+- Example: "Nike shoes under $100" → query "Nike shoes", facet_filters [["brand:Nike"]], then only present results where price < 100.
+- If the first search returns 0 results, simplify: broaden the query, remove category facets, keep only brand.
+
+**TOOL RESULTS**
+After using a search tool:
+- DO NOT list, enumerate, or repeat the product details from the tool output
+- DO NOT summarize individual products
+- The tool output (ProductCards, images, titles, links) is already displayed to the user
+- Only provide brief context if needed (e.g., "I found 5 laptops that match your criteria")
+- If the user asks about specific products, you may reference them without repeating all details
+
+**ORDERS & CUSTOMER SUPPORT**
+Use the `get_user_orders` tool when the user asks about their orders, past purchases, delivery status, or order history.
+- Summarize orders clearly: status, items, date, total. Do not dump raw JSON.
+- For status inquiries, explain what the current status means (e.g., "Your order is currently in delivery and should arrive soon").
+- If the user has an issue with an order (late delivery, wrong item, refund request), acknowledge their concern empathetically and guide them through available actions based on the order status.
+- Never fabricate order information. If the tool returns an error or the user is not logged in, ask them to sign in first.
+
+**PERSONALIZED RECOMMENDATIONS**
+IMPORTANT: Whenever the user references their past purchases, what they "already have", "already got", "bought before", or asks for complementary/similar/different items relative to their collection — you MUST call `get_user_orders` FIRST, before any search. Do not guess or search blindly.
+
+Examples that REQUIRE calling `get_user_orders` before searching:
+- "bags complementary to the ones I already got"
+- "something that goes with my last purchase"
+- "I need accessories for what I bought"
+- "suggest something different from what I have"
+- "what would pair well with my recent order?"
+
+Flow:
+1. Call `get_user_orders` to retrieve purchase history
+2. Analyze the purchased items (names, categories, brands, prices)
+3. Then search for complementary, upgraded, or related products
+4. Reference their history naturally: "Since you already have the Tote Leather Bag, these crossbody styles would complement your collection nicely..."
+
+If the user has no orders, let them know and fall back to popular items.
+
+**MEMORY**
+When you receive context like [Context:...] ALWAYS extract things to remember in order to drive more engaging and personalized conversations in future interactions. Combine memory context with order history for the richest personalization.
+```
+
+## Customization Notes
+
+- **Search limit**: Adjust `{{5}}` based on your cost tolerance. More searches = better results but higher LLM token costs.
+- **Tool results section**: This is critical — without it, the agent will redundantly describe every product card it already displayed, creating a poor UX.
+- **Personalization flow**: The "call orders first" pattern prevents the agent from guessing what the user owns.
+- **Price filtering caveat**: Algolia's search tool doesn't support numeric range filters in the chat context. The agent must search broadly and post-filter — make this explicit or it will try (and fail) to use price facets.

--- a/skills/agent-studio/references/authentication.md
+++ b/skills/agent-studio/references/authentication.md
@@ -1,0 +1,73 @@
+# User Authentication & Secure Tokens — Full Reference
+
+Memory and conversation scoping require user authentication via JWT tokens. The
+token is minted server-side (so the Agent Studio secret never reaches the
+browser) and passed to the Chat transport as the
+`X-Algolia-Secure-User-Token` header.
+
+## Server-side token generation
+
+The secret (`sk-alg-...`) and key ID come from Agent Studio
+**Settings > Authentication**. Sign an HS256 JWT whose `sub` is the user's ID
+and whose header carries the `kid`.
+
+```typescript
+import jwt from "jsonwebtoken";
+
+// Endpoint: POST /api/auth/algolia-token
+const token = jwt.sign(
+  { sub: userId },
+  process.env.ALGOLIA_SECRET_KEY, // sk-alg-... from Agent Studio Settings
+  {
+    expiresIn: "24h",
+    header: {
+      alg: "HS256",
+      typ: "JWT",
+      kid: process.env.ALGOLIA_KEY_ID, // Key ID from the same page
+    },
+  }
+);
+```
+
+## Client-side token management
+
+Cache the token and refresh it before it expires (decode the `exp` claim). Fall
+back to `null` for anonymous users so the Chat still works without memory.
+
+```typescript
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+async function fetchAlgoliaToken(): Promise<string | null> {
+  // Return cached token if it is not expiring within the next 5 minutes
+  if (cachedToken && cachedToken.expiresAt > Date.now() + 5 * 60 * 1000) {
+    return cachedToken.token;
+  }
+  try {
+    const { token } = await apiClient("/auth/algolia-token", { method: "POST" });
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    cachedToken = { token, expiresAt: payload.exp * 1000 };
+    return token;
+  } catch {
+    return null;
+  }
+}
+```
+
+Pass the token in the Chat transport headers as `X-Algolia-Secure-User-Token`
+(see the "Custom transport" section of SKILL.md).
+
+## Account switching / logout
+
+When a user logs out or switches accounts, clear the chat session storage so
+old conversations don't persist:
+
+```typescript
+const prefix = "instantsearch-chat-initial-messages";
+for (let i = sessionStorage.length - 1; i >= 0; i--) {
+  const key = sessionStorage.key(i);
+  if (key?.startsWith(prefix)) sessionStorage.removeItem(key);
+}
+```
+
+Also re-key the `<InstantSearch>` component on user change so React remounts the
+chat with a fresh session: `key={user?.id ?? "anon"}`.

--- a/skills/agent-studio/references/client-side-tools.md
+++ b/skills/agent-studio/references/client-side-tools.md
@@ -1,0 +1,113 @@
+# Client-Side Tools — Full Reference
+
+Client-side tools let the agent trigger actions in your frontend (fetch user
+data, update UI, add to cart, etc.). They follow the OpenAI Function Calling
+spec. You define the tool schema in the Agent Studio dashboard and register a
+handler on the `<Chat>` component in your React app.
+
+## The `layoutComponent` pattern (IMPORTANT)
+
+Use `layoutComponent` (NOT `onToolCall`) for async client-side tools. The
+`onToolCall` callback executes during the library's stream-processing phase,
+which can deadlock the internal `SerialJobExecutor` when combined with async
+work. `layoutComponent` defers execution to React's render cycle and avoids the
+deadlock.
+
+```tsx
+function MyToolHandler({
+  message,
+  addToolResult,
+}: {
+  message: { state: string };
+  addToolResult: (params: { output: unknown }) => void;
+  [key: string]: unknown;
+}) {
+  const fetchedRef = useRef(false);
+
+  useEffect(() => {
+    // Only execute when the tool is ready for input and hasn't run yet
+    if (message.state !== "input-available" || fetchedRef.current) return;
+    fetchedRef.current = true;
+
+    // Do your async work here
+    fetchSomeData()
+      .then((data) => addToolResult({ output: data }))
+      .catch((err) => addToolResult({ output: { error: err.message } }));
+  }, [message.state, addToolResult]);
+
+  // Render UI, or return an empty fragment for invisible tools
+  return <></>;
+}
+
+// Register on the Chat component
+<Chat
+  tools={{
+    my_tool_name: { layoutComponent: MyToolHandler },
+  }}
+/>;
+```
+
+**Key rules:**
+
+- The component receives `message` (with `state`), `addToolResult`,
+  `indexUiState`, and `setIndexUiState`.
+- Check `message.state === "input-available"` before executing.
+- Use `useRef` to prevent duplicate executions.
+- Always call `addToolResult` (even on error) so the agent can continue.
+- Tool keys must match the tool name configured in Agent Studio.
+
+## Tool definition in Agent Studio
+
+Register the tool in the Agent Studio dashboard under
+**Tools > Client-side tools**.
+
+Tool with no parameters (e.g. read the current user's data):
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "get_user_orders",
+    "description": "Retrieves the user's order history with IDs, statuses, totals, dates, and item details.",
+    "strict": true,
+    "parameters": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+Tool with parameters:
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "add_to_cart",
+    "description": "Adds a product to the user's shopping cart.",
+    "strict": true,
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "productId": {
+          "type": "string",
+          "description": "The Algolia objectID of the product to add"
+        },
+        "quantity": {
+          "type": ["integer", "null"],
+          "description": "Number of items to add (defaults to 1)"
+        }
+      },
+      "required": ["productId", "quantity"],
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+Set `"strict": true` in production for reliable schema adherence. With strict
+mode, ALL properties must appear in the `required` array, and optional fields
+must use the union type `["type", "null"]` (as `quantity` does above).

--- a/skills/agent-studio/references/components-and-css.md
+++ b/skills/agent-studio/references/components-and-css.md
@@ -1,0 +1,165 @@
+# Custom Components & CSS — Full Reference
+
+## Item component (product cards in chat)
+
+The item component receives Algolia hit objects. Field names depend on your
+index schema. Common fields: `objectID`, `name`/`title`, `price`, `image`,
+`brand`, `category`.
+
+```tsx
+<Chat
+  itemComponent={({ item }) => (
+    <Link
+      to={`/product/${item.objectID}`}
+      className="block w-40 shrink-0 rounded-xl overflow-hidden"
+    >
+      <img src={item.image} alt={item.name} className="w-full aspect-square object-cover" />
+      <div className="p-2">
+        <p className="text-sm font-bold truncate">{item.name}</p>
+        <span className="text-sm">${item.price}</span>
+      </div>
+    </Link>
+  )}
+/>
+```
+
+## Suggestions component
+
+Use the built-in CSS class names (`ais-ChatPromptSuggestions`,
+`ais-ChatPromptSuggestions-suggestion`) so the default styles and your
+overrides apply.
+
+```tsx
+<Chat
+  suggestionsComponent={({ suggestions = [], onSuggestionClick }) => {
+    if (suggestions.length === 0) return <></>;
+    return (
+      <div className="ais-ChatPromptSuggestions">
+        {suggestions.map((s) => (
+          <button
+            key={s}
+            className="ais-ChatPromptSuggestions-suggestion"
+            type="button"
+            onClick={() => onSuggestionClick(s)}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+    );
+  }}
+/>
+```
+
+## Other customizable components
+
+The Chat component accepts these additional component props:
+
+- `headerCloseIconComponent`, `headerMaximizeIconComponent`,
+  `headerMinimizeIconComponent`, `headerTitleIconComponent`
+- `messagesErrorComponent`, `messagesLoaderComponent`
+- `messageAssistantLeadingComponent`, `messageAssistantFooterComponent`
+- `messageUserLeadingComponent`, `messageUserFooterComponent`
+- `promptFooterComponent`, `promptHeaderComponent`
+- `toggleButtonIconComponent`
+
+## Translations
+
+```tsx
+<Chat
+  translations={{
+    prompt: {
+      textareaPlaceholder: "Ask me anything about our products...",
+      disclaimer: "AI-powered assistant. Responses may not be perfect.",
+      sendMessageTooltip: "Send",
+    },
+    header: {
+      title: "Shopping Assistant",
+    },
+  }}
+/>
+```
+
+## Design tokens (CSS custom properties)
+
+Set these on `.ais-Chat` to rebrand the widget:
+
+```css
+.ais-Chat {
+  --ais-primary-color-rgb: 0, 0, 0;          /* Primary brand color (RGB) */
+  --ais-primary-color-alpha: 1;
+  --ais-text-color-rgb: 26, 28, 29;           /* Main text */
+  --ais-muted-color-rgb: 71, 71, 71;          /* Secondary text */
+  --ais-background-color-rgb: 255, 255, 255;  /* Background */
+  --ais-background-color-alpha: 1;
+  --ais-border-color-rgb: 198, 198, 198;      /* Borders */
+  --ais-border-color-alpha: 0.25;
+  --ais-chat-margin: 1.5rem;                  /* Outer margin */
+  --ais-font-family: "Inter", system-ui, sans-serif;
+}
+```
+
+## Key CSS class names
+
+| Element | Class | Notes |
+|---------|-------|-------|
+| Root | `.ais-Chat` | Top-level container |
+| Panel | `.ais-Chat-container` | The chat panel |
+| Panel open | `.ais-Chat-container--open` | When chat is visible |
+| Toggle button | `.ais-ChatToggleButton` | Floating open/close button |
+| Header | `.ais-ChatHeader` | Title bar |
+| Header title | `.ais-ChatHeader-title` | Title text |
+| Messages area | `.ais-ChatMessages` | Scrollable message list |
+| Message | `.ais-ChatMessage` | Individual message |
+| User message | `.ais-ChatMessage--user` | User's messages |
+| Assistant message | `.ais-ChatMessage--assistant` | Agent's messages |
+| Message bubble | `.ais-ChatMessage-message` | The bubble itself |
+| Actions | `.ais-ChatMessage-actions` | Copy/regenerate buttons |
+| Prompt area | `.ais-ChatPrompt` | Input section |
+| Textarea | `.ais-ChatPrompt-textarea` | Input field |
+| Submit button | `.ais-ChatPrompt-submit` | Send button |
+| Suggestions | `.ais-ChatPromptSuggestions-suggestion` | Suggestion chips |
+| Product carousel | `.ais-ChatToolSearchIndexCarousel-list` | Product list container |
+| Product item | `.ais-ChatToolSearchIndexCarousel-item` | Individual product card |
+| Carousel header | `.ais-ChatToolSearchIndexCarouselHeader-title` | Section title above carousel |
+| Loader | `.ais-ChatMessages-loader` | Typing indicator |
+
+## Common customization patterns
+
+**Mobile bottom-sheet pattern** — position the chat above a mobile bottom nav
+and style it as a slide-up sheet:
+
+```css
+@media (max-width: 680px) {
+  .ais-Chat {
+    inset: auto 0 4rem 0 !important;  /* 4rem = bottom nav height */
+    max-height: calc(85vh - 4rem) !important;
+  }
+  .ais-Chat-container {
+    border-radius: 1.5rem 1.5rem 0 0 !important;
+  }
+  .ais-ChatToggleButton {
+    display: none !important; /* Use your own nav button instead */
+  }
+}
+```
+
+**Product carousel styling:**
+
+```css
+.ais-ChatMessage-message .ais-ChatToolSearchIndexCarousel-list {
+  display: flex !important;
+  gap: 0.75rem !important;
+  overflow-x: auto !important;
+  scroll-snap-type: x mandatory !important;
+  scrollbar-width: none !important;
+}
+.ais-ChatToolSearchIndexCarousel-item {
+  flex-shrink: 0 !important;
+  width: 10rem !important;
+  scroll-snap-align: start !important;
+}
+```
+
+For a complete CSS override file (monochrome design system), see
+`css-overrides-example.md`.

--- a/skills/agent-studio/references/context-injection.md
+++ b/skills/agent-studio/references/context-injection.md
@@ -1,0 +1,236 @@
+# Context Injection — Full Implementation
+
+## ChatContext Provider
+
+```tsx
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+
+interface ChatState {
+  chatIsOpen: boolean;
+  pendingMessage: string | null;
+  pendingContextMessage: string | null;
+  requestOpen: () => void;
+  requestClose: () => void;
+  requestOpenWithMessage: (message: string) => void;
+  consumePendingMessage: () => string | null;
+  sendWithContext: (context: string, visibleMessage?: string) => void;
+  consumePendingContextMessage: () => void;
+}
+
+const ChatContext = createContext<ChatState | null>(null);
+
+export function useChatActions() {
+  const ctx = useContext(ChatContext);
+  if (!ctx) throw new Error("useChatActions must be inside ChatProvider");
+  return ctx;
+}
+
+function isChatOpen(): boolean {
+  return !!document.querySelector(".ais-Chat-container--open");
+}
+
+function clickChatToggle() {
+  const btn = document.querySelector<HTMLButtonElement>(".ais-ChatToggleButton");
+  btn?.click();
+}
+
+export function ChatProvider({ children }: { children: React.ReactNode }) {
+  const [chatIsOpen, setChatIsOpen] = useState(false);
+  const [pendingMessage, setPendingMessage] = useState<string | null>(null);
+  const [pendingContextMessage, setPendingContextMessage] = useState<string | null>(null);
+
+  // Poll DOM for open/close state
+  useEffect(() => {
+    const interval = setInterval(() => setChatIsOpen(isChatOpen()), 150);
+    return () => clearInterval(interval);
+  }, []);
+
+  const requestOpen = useCallback(() => {
+    if (!isChatOpen()) clickChatToggle();
+  }, []);
+
+  const requestClose = useCallback(() => {
+    if (isChatOpen()) clickChatToggle();
+  }, []);
+
+  const requestOpenWithMessage = useCallback((msg: string) => {
+    setPendingMessage(msg);
+    if (!isChatOpen()) clickChatToggle();
+  }, []);
+
+  const consumePendingMessage = useCallback(() => {
+    const msg = pendingMessage;
+    setPendingMessage(null);
+    return msg;
+  }, [pendingMessage]);
+
+  const sendWithContext = useCallback(
+    (context: string, visibleMessage?: string) => {
+      const fullText = `[Context: ${context}]${visibleMessage || ""}`;
+
+      function injectAndSubmit() {
+        const textarea = document.querySelector<HTMLTextAreaElement>(
+          ".ais-ChatPrompt textarea, .ais-Chat textarea"
+        );
+        if (!textarea) return false;
+
+        // Set via native setter to trigger React's onChange
+        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+          window.HTMLTextAreaElement.prototype,
+          "value"
+        )?.set;
+        nativeInputValueSetter?.call(textarea, fullText);
+        textarea.dispatchEvent(new Event("input", { bubbles: true }));
+
+        // Submit after React processes input
+        setTimeout(() => {
+          const form = textarea.closest("form");
+          if (form) {
+            form.dispatchEvent(
+              new Event("submit", { bubbles: true, cancelable: true })
+            );
+          }
+        }, 50);
+        return true;
+      }
+
+      if (isChatOpen()) {
+        if (!injectAndSubmit()) {
+          let attempts = 0;
+          const retry = setInterval(() => {
+            if (injectAndSubmit() || ++attempts > 10) clearInterval(retry);
+          }, 100);
+        }
+      } else {
+        setPendingContextMessage(fullText);
+        setTimeout(clickChatToggle, 50);
+      }
+    },
+    []
+  );
+
+  const consumePendingContextMessage = useCallback(() => {
+    setPendingContextMessage(null);
+  }, []);
+
+  return (
+    <ChatContext.Provider
+      value={{
+        chatIsOpen,
+        pendingMessage,
+        pendingContextMessage,
+        requestOpen,
+        requestClose,
+        requestOpenWithMessage,
+        consumePendingMessage,
+        sendWithContext,
+        consumePendingContextMessage,
+      }}
+    >
+      {children}
+    </ChatContext.Provider>
+  );
+}
+```
+
+## Context Stripping Hook
+
+```tsx
+import { useEffect } from "react";
+
+const CONTEXT_PATTERN = /^\[Context:\s*([\s\S]*?)\]([\s\S]*)$/;
+const PROCESSED_ATTR = "data-ctx-stripped";
+
+export function useContextStripping() {
+  useEffect(() => {
+    function processUserMessage(el: Element) {
+      if (el.hasAttribute(PROCESSED_ATTR)) return;
+
+      const messageEl = el.querySelector(".ais-ChatMessage-message");
+      if (!messageEl) return;
+
+      const text = messageEl.textContent || "";
+      const match = text.match(CONTEXT_PATTERN);
+      if (!match) return;
+
+      el.setAttribute(PROCESSED_ATTR, "true");
+      const visibleText = match[2].trim();
+
+      if (!visibleText) {
+        // Context-only message: hide entirely
+        (el as HTMLElement).style.display = "none";
+      } else {
+        // Context + visible text: show only visible portion
+        messageEl.textContent = visibleText;
+      }
+    }
+
+    function scanAll() {
+      document
+        .querySelectorAll(`.ais-ChatMessage--right:not([${PROCESSED_ATTR}])`)
+        .forEach(processUserMessage);
+    }
+
+    // Use both MutationObserver and polling for reliability
+    const container = document.querySelector(".ais-Chat") || document.body;
+    const observer = new MutationObserver(() => scanAll());
+    observer.observe(container, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+
+    const poll = setInterval(scanAll, 300);
+    scanAll();
+
+    return () => {
+      observer.disconnect();
+      clearInterval(poll);
+    };
+  }, []);
+}
+```
+
+Call `useContextStripping()` inside your chat wrapper component (the one that renders `<Chat>`).
+
+## Provider Hierarchy
+
+```tsx
+<BrowserRouter>
+  <AuthProvider>
+    <CartProvider>
+      <ChatProvider>
+        <App />
+      </ChatProvider>
+    </CartProvider>
+  </AuthProvider>
+</BrowserRouter>
+```
+
+ChatProvider must wrap any component that calls `useChatActions()`.
+
+## Usage: Auto-inject context on product pages
+
+```tsx
+function ProductPage() {
+  const { chatIsOpen, sendWithContext } = useChatActions();
+  const product = useProduct();
+  const hasEngagedRef = useRef(false);
+
+  useEffect(() => {
+    if (!chatIsOpen || !product || hasEngagedRef.current) return;
+    hasEngagedRef.current = true;
+
+    const ctx = [
+      `User is browsing "${product.name}" (ID: ${product.objectID}).`,
+      `Price: $${product.price.toFixed(2)}.`,
+      product.brand ? `Brand: ${product.brand}.` : "",
+      product.category ? `Category: ${product.category}.` : "",
+      product.description ? `Description: ${product.description}` : "",
+      `Help the user with this product.`,
+    ].filter(Boolean).join(" ");
+
+    sendWithContext(ctx); // No visible message — context only, hidden from user
+  }, [chatIsOpen, product, sendWithContext]);
+}
+```

--- a/skills/agent-studio/references/css-overrides-example.md
+++ b/skills/agent-studio/references/css-overrides-example.md
@@ -1,0 +1,369 @@
+# CSS Overrides Example — Monochrome Design System
+
+This is a complete example of overriding the default Algolia Chat styles to match a monochrome/minimal design system. Use it as a starting template and adapt colors, fonts, and spacing to your brand.
+
+## Full CSS File
+
+```css
+/* Chat widget — Custom overrides */
+/* Layered on top of instantsearch.css/components/chat.css */
+
+/* ========== Design system token overrides ========== */
+.ais-Chat {
+  --ais-primary-color-rgb: 0, 0, 0;            /* primary color as RGB */
+  --ais-primary-color-alpha: 1;
+  --ais-text-color-rgb: 26, 28, 29;             /* main text */
+  --ais-muted-color-rgb: 71, 71, 71;            /* secondary text */
+  --ais-background-color-rgb: 255, 255, 255;    /* background */
+  --ais-background-color-alpha: 1;
+  --ais-border-color-rgb: 198, 198, 198;        /* borders */
+  --ais-border-color-alpha: 0.25;
+  --ais-chat-margin: 1.5rem;
+  --ais-font-family: "Inter", system-ui, sans-serif;
+  font-family: "Inter", system-ui, sans-serif;
+}
+
+/* Force font everywhere inside chat */
+.ais-Chat,
+.ais-Chat *,
+.ais-Chat *::before,
+.ais-Chat *::after {
+  font-family: "Inter", system-ui, sans-serif !important;
+}
+
+/* ========== Typography ========== */
+.ais-ChatHeader-title {
+  font-weight: 700 !important;
+  font-size: 0.9375rem !important;
+  letter-spacing: -0.02em !important;
+  color: #1a1c1d !important;
+}
+
+.ais-ChatMessage-message {
+  font-size: 0.875rem !important;
+  line-height: 1.55 !important;
+  letter-spacing: -0.006em !important;
+  color: #474747 !important;
+}
+
+.ais-ChatMessage--user .ais-ChatMessage-message {
+  color: #f0f0f2 !important;
+}
+
+.ais-ChatMessage-message strong,
+.ais-ChatMessage-message b {
+  font-weight: 600 !important;
+  color: #1a1c1d !important;
+}
+
+.ais-ChatMessage--user .ais-ChatMessage-message strong,
+.ais-ChatMessage--user .ais-ChatMessage-message b {
+  color: #ffffff !important;
+}
+
+/* Kill any remaining default blue on focus/active states */
+.ais-Chat *:focus,
+.ais-Chat *:focus-visible {
+  outline-color: #000000 !important;
+  border-color: #000000 !important;
+  box-shadow: none !important;
+}
+
+.ais-Chat *::selection {
+  background: rgba(0, 0, 0, 0.12) !important;
+  color: inherit !important;
+}
+
+/* ========== Mobile: position above bottom nav ========== */
+@media (max-width: 680px) {
+  .ais-Chat {
+    inset: auto 0 4rem 0 !important;  /* 4rem = bottom nav height */
+    height: auto !important;
+    max-height: calc(85vh - 4rem) !important;
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+}
+
+/* ========== Toggle button ========== */
+.ais-ChatToggleButton {
+  border-radius: 9999px !important;
+  background: rgba(255, 255, 255, 0.85) !important;
+  backdrop-filter: blur(24px) !important;
+  -webkit-backdrop-filter: blur(24px) !important;
+  box-shadow: 0px 20px 40px rgba(26, 28, 29, 0.06) !important;
+  border: 1px solid rgba(198, 198, 198, 0.3) !important;
+  width: 3.5rem !important;
+  height: 3.5rem !important;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) !important;
+}
+
+.ais-ChatToggleButton:hover {
+  transform: scale(1.08) !important;
+}
+
+.ais-ChatToggleButton:active {
+  transform: scale(0.95) !important;
+}
+
+/* Mobile: hide floating toggle when using bottom nav */
+@media (max-width: 680px) {
+  .ais-ChatToggleButton {
+    display: none !important;
+  }
+}
+
+/* ========== Panel container ========== */
+.ais-Chat-container {
+  background: #ffffff !important;
+  font-family: "Inter", system-ui, sans-serif !important;
+  border: 1px solid rgba(198, 198, 198, 0.15) !important;
+}
+
+/* Desktop: floating card */
+@media (min-width: 681px) {
+  .ais-Chat-container {
+    border-radius: 1rem !important;
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.08),
+                0 8px 20px rgba(0, 0, 0, 0.04) !important;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .ais-Chat-container {
+      transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+                  transform 0.5s cubic-bezier(0.4, 0, 0.2, 1) !important;
+    }
+    .ais-Chat-container.ais-Chat-container--open {
+      transition: opacity 0.35s cubic-bezier(0, 0, 0.2, 1),
+                  transform 0.45s cubic-bezier(0.16, 1, 0.3, 1) !important;
+    }
+  }
+}
+
+/* Mobile: bottom sheet with slide-up */
+@media (max-width: 680px) {
+  .ais-Chat-container {
+    border-radius: 1.5rem 1.5rem 0 0 !important;
+    border-bottom: none !important;
+    box-shadow: 0 -8px 50px rgba(0, 0, 0, 0.1),
+                0 -2px 15px rgba(0, 0, 0, 0.05) !important;
+    max-height: 85vh !important;
+  }
+
+  .ais-Chat-container {
+    transform: translateY(105%) !important;
+    opacity: 0 !important;
+    transition: transform 0.55s cubic-bezier(0.4, 0, 0.2, 1),
+                opacity 0.4s cubic-bezier(0.4, 0, 1, 1) !important;
+  }
+
+  .ais-Chat-container.ais-Chat-container--open {
+    transform: translateY(0) !important;
+    opacity: 1 !important;
+    transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+                opacity 0.3s cubic-bezier(0, 0, 0.2, 1) !important;
+  }
+
+  /* Drag handle */
+  .ais-Chat-container::before {
+    content: "" !important;
+    display: block !important;
+    width: 2.25rem !important;
+    height: 0.25rem !important;
+    background: rgba(0, 0, 0, 0.12) !important;
+    border-radius: 9999px !important;
+    margin: 0.625rem auto 0.25rem !important;
+    flex-shrink: 0 !important;
+  }
+}
+
+/* ========== Header ========== */
+.ais-ChatHeader {
+  background: #ffffff !important;
+  border-bottom: none !important;
+  color: #1a1c1d !important;
+}
+
+.ais-ChatHeader-clear,
+.ais-ChatHeader-close,
+.ais-ChatHeader-minimize,
+.ais-ChatHeader-maximize {
+  color: #474747 !important;
+}
+
+.ais-ChatHeader-clear:hover,
+.ais-ChatHeader-close:hover {
+  color: #1a1c1d !important;
+}
+
+/* ========== Messages ========== */
+.ais-ChatMessages {
+  background: #ffffff !important;
+}
+
+.ais-ChatMessage {
+  animation: chatMsgIn 0.35s cubic-bezier(0.16, 1, 0.3, 1) both !important;
+}
+
+@keyframes chatMsgIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* User bubble */
+.ais-ChatMessage--user .ais-ChatMessage-message {
+  background: #1a1c1d !important;
+  color: #f0f0f2 !important;
+  border-color: transparent !important;
+}
+
+/* Assistant bubble */
+.ais-ChatMessage--assistant .ais-ChatMessage-message {
+  background: #f3f3f5 !important;
+  color: #1a1c1d !important;
+  border-color: transparent !important;
+}
+
+/* Action icons */
+.ais-ChatMessage-actions button,
+.ais-ChatMessage-actions svg {
+  color: #777777 !important;
+}
+
+.ais-ChatMessage-actions button:hover,
+.ais-ChatMessage-actions button:hover svg {
+  color: #1a1c1d !important;
+}
+
+/* ========== Product carousel ========== */
+.ais-ChatMessage-message .ais-ChatToolSearchIndexCarousel-list,
+.ais-ChatMessage-message .ais-Recommend-list {
+  display: flex !important;
+  gap: 0.75rem !important;
+  overflow-x: auto !important;
+  padding: 0.25rem 0.25rem 0.5rem !important;
+  scrollbar-width: none !important;
+  scroll-snap-type: x mandatory !important;
+  -webkit-overflow-scrolling: touch !important;
+}
+
+.ais-ChatMessage-message .ais-ChatToolSearchIndexCarousel-list::-webkit-scrollbar,
+.ais-ChatMessage-message .ais-Recommend-list::-webkit-scrollbar {
+  display: none !important;
+}
+
+.ais-ChatMessage-message .ais-ChatToolSearchIndexCarousel-item,
+.ais-ChatMessage-message .ais-Recommend-item {
+  flex-shrink: 0 !important;
+  width: 10rem !important;
+  list-style: none !important;
+  scroll-snap-align: start !important;
+}
+
+/* Links */
+.ais-ChatToolSearchIndexCarouselHeaderResults a,
+.ais-ChatMessage-message a {
+  color: #1a1c1d !important;
+  text-decoration: underline !important;
+  text-underline-offset: 2px !important;
+}
+
+.ais-ChatMessage-message a:hover {
+  text-decoration: none !important;
+}
+
+/* ========== Prompt area ========== */
+.ais-ChatPrompt {
+  background: #ffffff !important;
+  border-top: 1px solid rgba(198, 198, 198, 0.12) !important;
+  padding: 0.5rem !important;
+  padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px)) !important;
+}
+
+.ais-ChatPrompt .ais-ChatPrompt-textarea {
+  font-size: 0.875rem !important;
+  color: #1a1c1d !important;
+  border-color: rgba(198, 198, 198, 0.3) !important;
+  caret-color: #000000 !important;
+  min-height: 0 !important;
+  max-height: 5rem !important;
+  padding: 0.5rem 0.625rem !important;
+}
+
+.ais-ChatPrompt .ais-ChatPrompt-textarea::placeholder {
+  color: #777777 !important;
+}
+
+.ais-ChatPrompt .ais-ChatPrompt-textarea:focus {
+  border-color: #000000 !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+/* Submit button */
+.ais-ChatPrompt-submit {
+  background: #000000 !important;
+  color: #e5e2e1 !important;
+  border-radius: 0.25rem !important;
+  border: none !important;
+  transition: opacity 0.2s ease !important;
+}
+
+.ais-ChatPrompt-submit:hover {
+  opacity: 0.85 !important;
+}
+
+.ais-ChatPrompt-submit svg {
+  color: #e5e2e1 !important;
+  fill: #e5e2e1 !important;
+}
+
+/* Footer text */
+.ais-ChatPrompt-footer {
+  color: #777777 !important;
+}
+
+/* ========== Suggestions ========== */
+.ais-ChatPromptSuggestions-suggestion {
+  border: 1px solid rgba(198, 198, 198, 0.4) !important;
+  border-radius: 0.75rem !important;
+  font-size: 0.8125rem !important;
+  color: #474747 !important;
+  transition: background 0.2s ease, border-color 0.2s ease !important;
+}
+
+.ais-ChatPromptSuggestions-suggestion:hover {
+  background: #f3f3f5 !important;
+  border-color: rgba(198, 198, 198, 0.6) !important;
+  color: #1a1c1d !important;
+}
+
+/* ========== Loading indicator ========== */
+.ais-ChatMessages-loader {
+  color: #474747 !important;
+}
+
+/* ========== Desktop scrollbar ========== */
+@media (min-width: 681px) {
+  .ais-ChatMessages-scroll::-webkit-scrollbar {
+    width: 4px;
+  }
+  .ais-ChatMessages-scroll::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .ais-ChatMessages-scroll::-webkit-scrollbar-thumb {
+    background: rgba(198, 198, 198, 0.4);
+    border-radius: 9999px;
+  }
+}
+```
+
+## Adapting to Other Brand Colors
+
+To adapt this to a different brand, change these key values:
+
+1. `--ais-primary-color-rgb` — your primary brand color as R, G, B
+2. `.ais-ChatMessage--user .ais-ChatMessage-message background` — user bubble color
+3. `.ais-ChatPrompt-submit background` — submit button color
+4. Focus/selection colors — match your primary
+5. Font family — replace "Inter" with your brand font

--- a/skills/agent-studio/references/insights-events.md
+++ b/skills/agent-studio/references/insights-events.md
@@ -84,10 +84,78 @@ client.pushEvents({ events: [{
 }]});
 ```
 
+## Attribute chat events to the agent's search
+
+In the chat flow the agent runs its searches server-side, so there is no
+client-side search to read a `queryID` from. Instead, every `algolia_search`
+tool result streamed to the client includes the `queryID` of the search the
+agent ran, alongside the `hits` it returned. Agent Studio runs these searches
+with click analytics enabled and tags them with `alg#agent-studio`, so click
+and conversion events that carry this `queryID` roll up as the agent's
+search-driven analytics: click-through rate, conversion rate, and revenue.
+
+Build a lookup from the streamed search tool results, then include the
+`queryID` (and the 1-based `position` for clicks) in the events you send for
+products the agent surfaced.
+
+```typescript
+type ChatSearchContext = { queryID: string; position: number };
+
+// Index { queryID, position } per objectID from the agent's algolia_search
+// tool results in an assistant message's parts. AI SDK v5 tool parts carry the
+// tool output; the search tool returns { hits, queryID }.
+function indexChatSearchResults(parts: any[], map: Map<string, ChatSearchContext>) {
+  for (const part of parts) {
+    const output = part?.output ?? part?.result;
+    if (!output?.queryID || !Array.isArray(output?.hits)) continue;
+    output.hits.forEach((hit: { objectID: string }, i: number) => {
+      map.set(hit.objectID, { queryID: output.queryID, position: i + 1 });
+    });
+  }
+}
+```
+
+```typescript
+// Click on a product the agent surfaced (click-after-search)
+function trackChatClick(objectID: string, ctx: ChatSearchContext) {
+  client.pushEvents({ events: [{
+    eventType: "click",
+    eventName: "Product Clicked in Chat",
+    index: indexName,
+    userToken: getUserToken(),
+    objectIDs: [objectID],
+    positions: [ctx.position],
+    queryID: ctx.queryID,
+  }]});
+}
+
+// Add to cart attributed to the agent's search (conversion-after-search)
+function trackChatAddToCart(objectID: string, price: string, ctx?: ChatSearchContext) {
+  client.pushEvents({ events: [{
+    eventType: "conversion",
+    eventSubtype: "addToCart",
+    eventName: "Added to Cart from Chat",
+    index: indexName,
+    userToken: getUserToken(),
+    objectIDs: [objectID],
+    ...(ctx ? { queryID: ctx.queryID } : {}),
+    objectData: [{ price, quantity: 1, ...(ctx ? { queryID: ctx.queryID } : {}) }],
+    currency: "USD",
+  }]});
+}
+```
+
+Wire `trackChatClick` into the chat's `itemComponent` (the product card) and
+`trackChatAddToCart` into your add-to-cart handler or client-side tool. Without
+the `queryID`, the events are still recorded, but they do not count as
+click-after-search or conversion-after-search, so the agent's contribution to
+click-through, conversion, and revenue is lost.
+
 ## Search-context attribution
 
-To connect clicks and conversions back to the search query that originated
-them, store the search context (queryID + position) when a product is clicked
+For products opened from a client-side InstantSearch results page (not the
+chat), connect clicks and conversions back to the search query that originated
+them: store the search context (queryID + position) when a product is clicked
 from search results, then retrieve it on the product page.
 
 ```typescript

--- a/skills/agent-studio/references/insights-events.md
+++ b/skills/agent-studio/references/insights-events.md
@@ -1,0 +1,107 @@
+# Algolia Insights Events — Full Reference
+
+Track user behavior to power Algolia analytics and AI Personalization. Events
+are sent with the lite client's `pushEvents` method.
+
+## Setup
+
+```typescript
+import { liteClient as algoliasearch } from "algoliasearch/lite";
+const client = algoliasearch(appId, apiKey);
+```
+
+## User token management
+
+Use a stable random token for anonymous users, and switch to the authenticated
+user ID once the user logs in.
+
+```typescript
+// Anonymous users: stable random token in localStorage
+function getOrCreateAnonToken(): string {
+  let token = localStorage.getItem("algolia_anon_token");
+  if (!token) {
+    token = `anon-${crypto.randomUUID()}`;
+    localStorage.setItem("algolia_anon_token", token);
+  }
+  return token;
+}
+
+// On login: switch to authenticated user ID
+let authenticatedToken: string | null = null;
+function setInsightsUserToken(userId: string | null) {
+  authenticatedToken = userId;
+}
+function getUserToken(): string {
+  return authenticatedToken ?? getOrCreateAnonToken();
+}
+```
+
+## Event types
+
+```typescript
+// View events
+client.pushEvents({ events: [{
+  eventType: "view",
+  eventName: "Product Viewed",
+  index: indexName,
+  userToken: getUserToken(),
+  objectIDs: [objectID],
+}]});
+
+// Click after search (requires queryID from the search response)
+client.pushEvents({ events: [{
+  eventType: "click",
+  eventName: "Product Clicked after Search",
+  index: indexName,
+  userToken: getUserToken(),
+  objectIDs: [objectID],
+  positions: [position], // 1-based position in search results
+  queryID: queryID,
+}]});
+
+// Add to cart (conversion with revenue)
+client.pushEvents({ events: [{
+  eventType: "conversion",
+  eventSubtype: "addToCart",
+  eventName: "Product Added to Cart",
+  index: indexName,
+  userToken: getUserToken(),
+  objectIDs: [objectID],
+  objectData: [{ price: "29.99", quantity: 1 }],
+  currency: "USD",
+}]});
+
+// Purchase (conversion with revenue)
+client.pushEvents({ events: [{
+  eventType: "conversion",
+  eventSubtype: "purchase",
+  eventName: "Products Purchased",
+  index: indexName,
+  userToken: getUserToken(),
+  objectIDs: objectIDs,
+  objectData: items.map((i) => ({ price: i.price.toFixed(2), quantity: i.quantity })),
+  currency: "USD",
+}]});
+```
+
+## Search-context attribution
+
+To connect clicks and conversions back to the search query that originated
+them, store the search context (queryID + position) when a product is clicked
+from search results, then retrieve it on the product page.
+
+```typescript
+// On search result click
+function storeSearchContext(ctx: { queryID: string; position: number; objectID: string }) {
+  sessionStorage.setItem(`search_ctx_${ctx.objectID}`, JSON.stringify(ctx));
+}
+
+// On product page load
+function consumeSearchContext(objectID: string) {
+  const key = `search_ctx_${objectID}`;
+  const raw = sessionStorage.getItem(key);
+  if (!raw) return null;
+  sessionStorage.removeItem(key);
+  return JSON.parse(raw);
+}
+```

--- a/skills/agent-studio/references/insights-events.md
+++ b/skills/agent-studio/references/insights-events.md
@@ -87,23 +87,30 @@ client.pushEvents({ events: [{
 ## Attribute chat events to the agent's search
 
 In the chat flow the agent runs its searches server-side, so there is no
-client-side search to read a `queryID` from. Instead, every `algolia_search`
-tool result streamed to the client includes the `queryID` of the search the
-agent ran, alongside the `hits` it returned. Agent Studio runs these searches
-with click analytics enabled and tags them with `alg#agent-studio`, so click
-and conversion events that carry this `queryID` roll up as the agent's
-search-driven analytics: click-through rate, conversion rate, and revenue.
+client-side search to read a `queryID` from. Instead, the search tool result
+streamed to the client includes the `queryID` of the search the agent ran,
+alongside the `hits` it returned. Do not filter by a hardcoded tool name: the
+search tool's type and default name is `algolia_search_index`, but it is
+configurable per tool (custom names, or MCP-suffixed like
+`algolia_search_index_products`). The robust approach is to iterate every
+streamed tool result part and key off any part that carries both a `queryID`
+and `hits` — which is exactly what `indexChatSearchResults` below does. Agent
+Studio runs these searches with click analytics enabled and tags them with
+`alg#agent-studio`, so click and conversion events that carry this `queryID`
+roll up as the agent's search-driven analytics: click-through rate, conversion
+rate, and revenue.
 
-Build a lookup from the streamed search tool results, then include the
+Build a lookup by iterating the streamed tool result parts, then include the
 `queryID` (and the 1-based `position` for clicks) in the events you send for
 products the agent surfaced.
 
 ```typescript
 type ChatSearchContext = { queryID: string; position: number };
 
-// Index { queryID, position } per objectID from the agent's algolia_search
-// tool results in an assistant message's parts. AI SDK v5 tool parts carry the
-// tool output; the search tool returns { hits, queryID }.
+// Index { queryID, position } per objectID by iterating the assistant
+// message's tool result parts. Do not match on tool name (it is configurable,
+// default `algolia_search_index`) — key off parts whose output has both a
+// queryID and hits. AI SDK v5 tool parts carry the tool output.
 function indexChatSearchResults(parts: any[], map: Map<string, ChatSearchContext>) {
   for (const part of parts) {
     const output = part?.output ?? part?.result;

--- a/skills/agent-studio/references/insights-events.md
+++ b/skills/agent-studio/references/insights-events.md
@@ -87,57 +87,67 @@ client.pushEvents({ events: [{
 ## Attribute chat events to the agent's search
 
 In the chat flow the agent runs its searches server-side, so there is no
-client-side search to read a `queryID` from. Instead, the search tool result
-streamed to the client includes the `queryID` of the search the agent ran,
-alongside the `hits` it returned. Do not filter by a hardcoded tool name: the
-search tool's type and default name is `algolia_search_index`, but it is
-configurable per tool (custom names, or MCP-suffixed like
-`algolia_search_index_products`). The robust approach is to iterate every
-streamed tool result part and key off any part that carries both a `queryID`
-and `hits` — which is exactly what `indexChatSearchResults` below does. Agent
-Studio runs these searches with click analytics enabled and tags them with
-`alg#agent-studio`, so click and conversion events that carry this `queryID`
-roll up as the agent's search-driven analytics: click-through rate, conversion
-rate, and revenue.
+client-side search to read a `queryID` from. Instead, `react-instantsearch`
+stamps a per-query token onto every hit it renders in the chat carousel: the
+`queryID` lives on the hit itself as `item.__queryID`. The chat's
+`itemComponent` receives the real InstantSearch props — the hit (`item`) and a
+built-in `sendEvent` helper — so both clicks and conversions attribute
+themselves from the hit. Do not read the assistant message's streamed `parts`
+and do not match on a tool name: the search tool is renameable per agent
+(`algolia_search_index`, a custom name, or an MCP-suffixed variant), and the
+chat's message-footer component in this version of `react-instantsearch`
+receives no message, so it cannot read the results at all. The hit is the
+reliable, library-idiomatic source.
 
-Build a lookup by iterating the streamed tool result parts, then include the
-`queryID` (and the 1-based `position` for clicks) in the events you send for
-products the agent surfaced.
+Agent Studio runs the agent's searches with click analytics enabled and tags
+them with `alg#agent-studio`, so click and conversion events that carry this
+`queryID` roll up as the agent's search-driven analytics: click-through rate,
+conversion rate, and revenue.
 
-```typescript
-type ChatSearchContext = { queryID: string; position: number };
+### Clicks: fire the built-in `sendEvent`
 
-// Index { queryID, position } per objectID by iterating the assistant
-// message's tool result parts. Do not match on tool name (it is configurable,
-// default `algolia_search_index`) — key off parts whose output has both a
-// queryID and hits. AI SDK v5 tool parts carry the tool output.
-function indexChatSearchResults(parts: any[], map: Map<string, ChatSearchContext>) {
-  for (const part of parts) {
-    const output = part?.output ?? part?.result;
-    if (!output?.queryID || !Array.isArray(output?.hits)) continue;
-    output.hits.forEach((hit: { objectID: string }, i: number) => {
-      map.set(hit.objectID, { queryID: output.queryID, position: i + 1 });
-    });
-  }
+For a click on a product card, call the `sendEvent` helper the `itemComponent`
+receives. InstantSearch derives the `queryID` and 1-based position from the hit,
+so there is no manual `pushEvents` call for clicks.
+
+```tsx
+// components/ChatWidget.tsx — product card rendered in the chat carousel.
+function ChatProductCard({ item, sendEvent }) {
+  // Record this hit's queryID + price so a later add-to-cart can attribute
+  // itself to the agent's search (see recordSearchHit below).
+  recordSearchHit(item.objectID, item.__queryID, item.price);
+
+  return (
+    <div onClick={() => sendEvent("click", item, "Product Clicked in Chat")}>
+      {item.name} — ${item.price}
+    </div>
+  );
 }
 ```
 
+### Conversions: look up the recorded `queryID`
+
+Add-to-cart and purchase are triggered by a client-side tool, not by a hit
+click, so they cannot use `sendEvent`. Record `objectID -> { queryID, price }`
+as each card renders, then look it up on the conversion and send a
+conversion-after-search event carrying that `queryID`. A conversion event needs
+no `positions`.
+
 ```typescript
-// Click on a product the agent surfaced (click-after-search)
-function trackChatClick(objectID: string, ctx: ChatSearchContext) {
-  client.pushEvents({ events: [{
-    eventType: "click",
-    eventName: "Product Clicked in Chat",
-    index: indexName,
-    userToken: getUserToken(),
-    objectIDs: [objectID],
-    positions: [ctx.position],
-    queryID: ctx.queryID,
-  }]});
+// lib/insights.ts — remember each hit, then attribute the conversion.
+const queryIdByObjectID = new Map<string, { queryID?: string; price?: string }>();
+
+export function recordSearchHit(objectID: string, queryID?: string, price?: number | string) {
+  queryIdByObjectID.set(objectID, {
+    queryID,
+    price: price != null ? String(price) : undefined,
+  });
 }
 
-// Add to cart attributed to the agent's search (conversion-after-search)
-function trackChatAddToCart(objectID: string, price: string, ctx?: ChatSearchContext) {
+export function trackChatAddToCart(objectID: string, quantity = 1) {
+  const ctx = queryIdByObjectID.get(objectID);
+  const price = ctx?.price ?? "0.00";
+
   client.pushEvents({ events: [{
     eventType: "conversion",
     eventSubtype: "addToCart",
@@ -145,18 +155,21 @@ function trackChatAddToCart(objectID: string, price: string, ctx?: ChatSearchCon
     index: indexName,
     userToken: getUserToken(),
     objectIDs: [objectID],
-    ...(ctx ? { queryID: ctx.queryID } : {}),
-    objectData: [{ price, quantity: 1, ...(ctx ? { queryID: ctx.queryID } : {}) }],
+    // Attach the queryID only when the product came from an agent search.
+    ...(ctx?.queryID ? { queryID: ctx.queryID } : {}),
+    objectData: [{ price, quantity, ...(ctx?.queryID ? { queryID: ctx.queryID } : {}) }],
     currency: "USD",
   }]});
 }
 ```
 
-Wire `trackChatClick` into the chat's `itemComponent` (the product card) and
-`trackChatAddToCart` into your add-to-cart handler or client-side tool. Without
-the `queryID`, the events are still recorded, but they do not count as
-click-after-search or conversion-after-search, so the agent's contribution to
-click-through, conversion, and revenue is lost.
+Wire `recordSearchHit` and the `sendEvent` click into the chat's `itemComponent`
+(the product card), and `trackChatAddToCart` into your add-to-cart handler or
+client-side tool. Without the `queryID`, the events are still recorded, but they
+do not count as click-after-search or conversion-after-search, so the agent's
+contribution to click-through, conversion, and revenue is lost.
+
+For a complete working example, see `examples/coding-with-ai-nextjs`.
 
 ## Search-context attribution
 

--- a/skills/agent-studio/references/memory.md
+++ b/skills/agent-studio/references/memory.md
@@ -1,0 +1,81 @@
+# Memory & Personalization — Full Reference
+
+Memory lets the agent remember facts about users across conversations.
+
+## Enabling memory
+
+1. Enable in the Agent Studio dashboard: **Customizations > Memory** toggle.
+2. Set data retention to 30 / 60 / 90 days (NOT 0 — 0 disables persistence).
+3. Require user authentication (see `authentication.md`). Memory is scoped to
+   the authenticated user via the `X-Algolia-Secure-User-Token`.
+
+## Memory types
+
+- **Semantic** — stable user facts and preferences ("User prefers dark mode",
+  "User is allergic to peanuts").
+- **Episodic** — agent reasoning chains (Observation / Thoughts / Action /
+  Result).
+
+## Memory tools (auto-added when memory is enabled)
+
+- `algolia_memorize` — saves semantic memories.
+- `algolia_ponder` — saves episodic memories (reasoning).
+- `algolia_memory_search` — searches existing memories.
+
+## Memory channel pattern
+
+Send background context to the agent for memory storage without showing it in
+the chat UI. Fire a completion request whose message is prefixed with
+`[MEMORY]`, then consume (and discard) the response body.
+
+```typescript
+async function sendMemoryToAgent(memory: string): Promise<{ success: boolean }> {
+  const token = await fetchAlgoliaToken();
+  const response = await fetch(
+    `https://${appId}.algolia.net/agent-studio/1/agents/${agentId}/completions?compatibilityMode=ai-sdk-5`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-algolia-application-id": appId,
+        "x-algolia-api-Key": apiKey,
+        "X-Algolia-Secure-User-Token": token,
+      },
+      body: JSON.stringify({
+        id: crypto.randomUUID(),
+        messages: [
+          {
+            role: "user",
+            parts: [
+              {
+                type: "text",
+                text: `[MEMORY] Remember this about the current user: ${memory}`,
+              },
+            ],
+          },
+        ],
+      }),
+    }
+  );
+  await response.text(); // Consume the streamed body
+  return { success: response.ok };
+}
+```
+
+**When to send memory events:**
+
+- Product page views: `"User viewed '{name}' priced at ${price} by {brand}"`
+- Add to cart: `"User added {quantity}x '{name}' to cart"`
+- Purchases: `"User purchased {items} for ${total}"`
+
+## Agent prompt for memory
+
+Include a memory instruction in the agent's system prompt so it processes
+context for personalization:
+
+```text
+**MEMORY**
+When you receive context like [Context:...] ALWAYS extract things to remember
+to drive more engaging and personalized conversations in future interactions.
+Combine memory context with order history for the richest personalization.
+```

--- a/skills/agent-studio/references/prompt-starters.md
+++ b/skills/agent-studio/references/prompt-starters.md
@@ -1,0 +1,227 @@
+# Prompt Starters — Full Implementation
+
+Generate personalized AI conversation starters on product pages using a dedicated Agent Studio agent.
+
+## Architecture
+
+- A **separate agent** (with its own `VITE_ALGOLIA_PROMPT_STARTERS_AGENT_ID`) generates starters
+- The agent is called directly via the API (not through the Chat widget)
+- A `display_prompt_starters` client-side tool forces structured output
+- The streamed response is parsed for the tool call arguments
+- Starters are rendered as buttons that open the main chat with context
+
+## Component
+
+```tsx
+import { useEffect, useState } from "react";
+import { fetchAlgoliaToken } from "../../lib/apiClient";
+import { useChatActions } from "../../context/ChatContext";
+
+const agentId = import.meta.env.VITE_ALGOLIA_PROMPT_STARTERS_AGENT_ID;
+const appId = import.meta.env.VITE_ALGOLIA_APP_ID;
+const apiKey = import.meta.env.VITE_ALGOLIA_SEARCH_API_KEY;
+
+interface Props {
+  product: {
+    objectID: string;
+    name: string;
+    price: number;
+    brand?: string;
+    category?: string;
+    description?: string;
+    rating?: number;
+  };
+}
+
+export default function PromptStarters({ product }: Props) {
+  const [starters, setStarters] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { sendWithContext } = useChatActions();
+
+  useEffect(() => {
+    if (!agentId || !appId || !apiKey) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchStarters() {
+      const token = await fetchAlgoliaToken();
+      if (cancelled) return;
+
+      // Build product context string
+      const productContext = [
+        `Product: "${product.name}"`,
+        `Price: $${product.price.toFixed(2)}`,
+        product.brand ? `Brand: ${product.brand}` : "",
+        product.category ? `Category: ${product.category}` : "",
+        product.description ? `Description: ${product.description}` : "",
+        product.rating != null ? `Rating: ${product.rating.toFixed(1)}/5` : "",
+      ]
+        .filter(Boolean)
+        .join(". ");
+
+      try {
+        const url = `https://${appId}.algolia.net/agent-studio/1/agents/${agentId}/completions?compatibilityMode=ai-sdk-5`;
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+          "x-algolia-application-id": appId!,
+          "x-algolia-api-Key": apiKey!,
+        };
+        if (token) {
+          headers["X-Algolia-Secure-User-Token"] = token;
+        }
+
+        const res = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            id: crypto.randomUUID(),
+            messages: [
+              {
+                role: "user",
+                parts: [{ type: "text", text: productContext }],
+              },
+            ],
+            // Define a client-side tool to force structured output
+            tools: [
+              {
+                type: "function",
+                name: "display_prompt_starters",
+                description:
+                  "Display personalized prompt starter suggestions on the product page to engage the user into a conversation.",
+                parameters: {
+                  type: "object",
+                  properties: {
+                    starters: {
+                      type: "array",
+                      description:
+                        "Exactly 3 prompt starter questions tailored to the product and user context.",
+                      items: {
+                        type: "string",
+                        description:
+                          "A short, natural question the user might ask about the product. Max 140 characters.",
+                      },
+                      minItems: 3,
+                      maxItems: 3,
+                    },
+                  },
+                  required: ["starters"],
+                  additionalProperties: false,
+                },
+              },
+            ],
+            // Force the agent to use this tool
+            toolChoice: {
+              type: "function",
+              name: "display_prompt_starters",
+            },
+          }),
+        });
+
+        if (!res.ok || !res.body) {
+          setLoading(false);
+          return;
+        }
+
+        const text = await res.text();
+        const parsed = parseStarters(text);
+        if (!cancelled && parsed.length > 0) {
+          setStarters(parsed);
+        }
+      } catch {
+        // Non-critical — just don't show starters
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchStarters();
+    return () => {
+      cancelled = true;
+    };
+  }, [product.objectID]);
+
+  function handleClick(starter: string) {
+    const ctx = `The user is viewing product "${product.name}" (ID: ${product.objectID}, price: $${product.price.toFixed(2)}${product.brand ? `, brand: ${product.brand}` : ""}${product.category ? `, category: ${product.category}` : ""}). Answer their question about this product.`;
+    sendWithContext(ctx, starter);
+  }
+
+  if (loading || starters.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 mt-4">
+      {starters.map((s) => (
+        <button
+          key={s}
+          onClick={() => handleClick(s)}
+          className="px-3 py-2 text-sm border rounded-lg hover:bg-gray-50 transition-colors"
+        >
+          {s}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+## Parsing the Streamed Response
+
+The AI SDK 5 stream sends newline-delimited `data: {JSON}` events. The tool arguments come through as:
+- `tool-input-delta` events (incremental chunks)
+- `tool-input-available` event (complete parsed input)
+
+```typescript
+function parseStarters(raw: string): string[] {
+  let toolArgs = "";
+
+  for (const line of raw.split("\n")) {
+    if (!line.startsWith("data: ")) continue;
+    const payload = line.slice(6);
+    try {
+      const obj = JSON.parse(payload);
+
+      // Best case: complete input available
+      if (
+        obj.type === "tool-input-available" &&
+        obj.toolName === "display_prompt_starters" &&
+        Array.isArray(obj.input?.starters)
+      ) {
+        return obj.input.starters;
+      }
+
+      // Accumulate deltas as fallback
+      if (
+        obj.type === "tool-input-delta" &&
+        typeof obj.inputTextDelta === "string"
+      ) {
+        toolArgs += obj.inputTextDelta;
+      }
+    } catch {
+      // Not JSON, skip
+    }
+  }
+
+  // Try parsing accumulated args
+  if (toolArgs) {
+    try {
+      const parsed = JSON.parse(toolArgs);
+      if (Array.isArray(parsed.starters)) {
+        return parsed.starters;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  return [];
+}
+```
+
+## Agent Setup for Prompt Starters
+
+Create a separate agent in Agent Studio with:
+- **System prompt**: "Generate exactly 3 short, natural questions a shopper might ask about the given product. Questions should be engaging and help the user start a conversation."
+- **Tool**: Add the `display_prompt_starters` tool definition (same as above)
+- **No search tools needed** — this agent just generates questions based on the product context

--- a/skills/algobot-cli/SKILL.md
+++ b/skills/algobot-cli/SKILL.md
@@ -38,10 +38,13 @@ npm install -g algobot-ai
 algobot init                    # Interactive wizard (creates first agent + profile)
 ```
 
-Or add a profile manually (CI-safe, non-interactive):
+Or add a profile manually (CI-safe, non-interactive). Pass your app ID and Admin API key so the profile is authenticated:
 ```bash
-algobot profiles add --name prod --env prod
+algobot profiles add --name prod --env prod \
+  --app-id <APP_ID> --api-key "$ALGOBOT_ADMIN_KEY" \
+  --default-agent-id pending --default
 ```
+Without `--app-id` and `--api-key`, the profile is created but not authenticated, so commands fail. Read the key from an environment variable rather than hardcoding it, and use `--default-agent-id pending` when no agent exists yet (set it after you create one).
 
 ## Non-Interactive Mode (Critical for Agents)
 
@@ -82,7 +85,7 @@ algobot --verbose ask "debug this"           # Show full HTTP traces
 
 ```bash
 algobot profiles list
-algobot profiles add --name dev --env dev
+algobot profiles add --name dev --env dev --app-id <APP_ID> --api-key "$ALGOBOT_ADMIN_KEY"  # include creds to authenticate
 algobot profiles setdefault prod
 algobot --profile prod agents list
 algobot --env dev agents list

--- a/skills/algobot-cli/SKILL.md
+++ b/skills/algobot-cli/SKILL.md
@@ -65,13 +65,15 @@ algobot agents list --jq '.[] | .name'                       # JSON filtering
 ```bash
 algobot agents list
 algobot agents get <agent-id>
-algobot agents create --name "Support Bot" --model gpt-4o
+algobot agents create --name "Support Bot" --model gpt-5.6-luna
 algobot agents update <agent-id> --name "New Name"
 algobot agents publish <agent-id>
 algobot agents unpublish <agent-id>
 algobot agents delete <agent-id>
 algobot agents copy <id> --from-env dev --to-env prod
 ```
+
+Default new agents on an OpenAI provider to `gpt-5.6-luna` (the cost-efficient GPT-5.6 tier). Pass a different `--model` when you need another model.
 
 ### Chatting with an Agent
 

--- a/skills/algobot-cli/SKILL.md
+++ b/skills/algobot-cli/SKILL.md
@@ -65,7 +65,7 @@ algobot agents list --jq '.[] | .name'                       # JSON filtering
 ```bash
 algobot agents list
 algobot agents get <agent-id>
-algobot agents create --name "Support Bot" --model gpt-5.6-luna
+algobot agents create --name "Support Bot" --model gpt-5.6-terra
 algobot agents update <agent-id> --name "New Name"
 algobot agents publish <agent-id>
 algobot agents unpublish <agent-id>
@@ -73,7 +73,7 @@ algobot agents delete <agent-id>
 algobot agents copy <id> --from-env dev --to-env prod
 ```
 
-Default new agents on an OpenAI provider to `gpt-5.6-luna` (the cost-efficient GPT-5.6 tier). Pass a different `--model` when you need another model.
+Default new agents on an OpenAI provider to `gpt-5.6-terra` (the balanced cost/quality GPT-5.6 tier). Pass a different `--model` when you need another model.
 
 ### Chatting with an Agent
 

--- a/skills/algobot-cli/references/commands.md
+++ b/skills/algobot-cli/references/commands.md
@@ -30,7 +30,7 @@ algobot interactive --text "<prompt> ||| <prompt2>"  # Scripted multi-turn
 
 ```bash
 algobot profiles list
-algobot profiles add --name <name> --env <dev|staging|prod>
+algobot profiles add --name <name> --env <dev|staging|prod> --app-id <APP_ID> --api-key <ADMIN_API_KEY> [--default-agent-id <id|pending>] [--default]
 algobot profiles show [name]                          # JSON output
 algobot profiles setdefault <name>
 algobot profiles remove <name>

--- a/skills/algobot-cli/references/config-as-code.md
+++ b/skills/algobot-cli/references/config-as-code.md
@@ -25,7 +25,7 @@ Produces `agent-config.json` with the agent's current config, and `PROMPT.md` if
 ```json
 {
   "name": "{{event_name}} Support Bot",
-  "model": "gpt-5.6-luna",
+  "model": "gpt-5.6-terra",
   "instructions": "PROMPT.md",
   "tools": [
     {

--- a/skills/algobot-cli/references/config-as-code.md
+++ b/skills/algobot-cli/references/config-as-code.md
@@ -25,7 +25,7 @@ Produces `agent-config.json` with the agent's current config, and `PROMPT.md` if
 ```json
 {
   "name": "{{event_name}} Support Bot",
-  "model": "gpt-4o",
+  "model": "gpt-5.6-luna",
   "instructions": "PROMPT.md",
   "tools": [
     {

--- a/skills/algobot-cli/references/config-as-code.md
+++ b/skills/algobot-cli/references/config-as-code.md
@@ -48,6 +48,33 @@ Produces `agent-config.json` with the agent's current config, and `PROMPT.md` if
 
 > Top-level `indexName` is silently stripped — index names belong in `tools[].indices[].index`.
 
+### Search tool: static vs dynamic indices
+
+The `algolia_search_index` tool has a `mode` field for dynamic-index support. `static` is the default, so existing agents are unaffected.
+
+```json
+{
+  "type": "algolia_search_index",
+  "name": "search_products",
+  "mode": "dynamic",
+  "allowUnlistedIndices": false,
+  "indices": [
+    {
+      "index": "{{index_name}}",
+      "description": "Product catalog. Search by title, brand, or category.",
+      "enhancedDescription": "Extra attribute and facet hints for the model.",
+      "searchParameters": { "optionalFilters": ["brand:Acme"] }
+    }
+  ]
+}
+```
+
+- `mode` (default `"static"`):
+  - `static` — `indices` is the only set the tool searches. A per-request `algolia.indices` override returns HTTP 422.
+  - `dynamic` — a completion request can pass `algolia.indices` (up to 10) to replace the list for that request; without it, `indices` is used. Per-request names must be a subset of `indices` by default; net-new names return 422 (`index_not_listed_on_tool`).
+- `allowUnlistedIndices` (default `false`, dynamic only) — set `true` to accept any index the agent's API key can reach, not only those listed. It errors at save time under `mode: "static"`.
+- Per index, besides `index` and `description`: `enhancedDescription`, `searchParameters` (default Algolia search parameters), and `searchControls` (used when Algolia MCP is enabled).
+
 ## Template Variables
 
 ```bash

--- a/skills/algolia-mcp/SKILL.md
+++ b/skills/algolia-mcp/SKILL.md
@@ -13,7 +13,8 @@ metadata:
 
 ## Connection setup
 
-Use `/algolia-mcp:mcp-connect` to configure the MCP client with the Algolia MCP server.
+First enable the Algolia MCP server in the dashboard (Generate AI → MCP Servers → Productivity). This is a one-time toggle.
+Then use `/algolia-mcp:mcp-connect` to configure the MCP client with the Algolia MCP server.
 For manual client setup, see [connection-setup](references/connection-setup.md).
 
 ## Tool selection


### PR DESCRIPTION
## Lab Week draft — promote the `agent-studio` frontend chat skill

**Status: draft / WIP.** Opening for early feedback during Lab Week.

Adds a new `agent-studio` skill so customers can build an Agent Studio chat experience on their own website from their AI coding assistant. It was previously a local-only skill; this promotes it into the public repo alongside the other six skills.

### What's included
- `skills/agent-studio/SKILL.md` — lean guide (355 lines) covering widget setup and custom transport, client-side tools (the `layoutComponent` pattern), Algolia Insights (business) events, secure user authentication, memory, context injection, prompt starters, and CSS.
- `skills/agent-studio/references/*` — detailed code kept out of `SKILL.md` to stay under the 500-line spec limit: `client-side-tools.md`, `insights-events.md`, `authentication.md`, `components-and-css.md`, `memory.md`, `context-injection.md`, `prompt-starters.md`, `agent-prompt-example.md`, `css-overrides-example.md`.
- `skills/agent-studio/evals/evals.json` — 3 evals.
- Registered in `.claude-plugin/marketplace.json` and the README skills table.

### Verified
- `python3 scripts/validate_skills.py` → **52 passed, 0 failed**.

### Verification checklist (before marking ready)
- [ ] Install and trigger the skill in Claude Code, Codex, and Cursor from a clean profile.
- [ ] Confirm the `/plugin install agent-studio` marketplace flow.
- [ ] Review the description and trigger wording against the sibling docs PR.
- [ ] Confirm code samples against the current `react-instantsearch` Chat API.

Paired with the docs section in `algolia/docs-new` (branch `labweek/coding-with-ai`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
