### PR TITLE
feat: add algolia-implementation planning suite (11 skills)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,6 +62,25 @@
       "skills": [
         "./skills/algolia-quickstart"
       ]
+    },
+    {
+      "name": "algolia-implementation",
+      "description": "Implementation-planning suite that spans the full Algolia lifecycle: discovery and phase planning, data modeling, index configuration, UI library selection, InstantSearch and Autocomplete readiness, events/Insights instrumentation, NeuralSearch and Agent Studio rollout, and release QA. Use when planning, building, migrating, auditing, or validating an Algolia implementation end to end — it sequences the work, makes data/event contracts explicit, and routes live operations to algolia-cli, algolia-mcp, algobot-cli, and code-level work to instantsearch. Install as a bundle: algolia-discovery-planning is the entry point and loads the companion skills per phase. Do NOT use for direct account operations or as the source of truth for current framework APIs — the official skills above own those.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/algolia-discovery-planning",
+        "./skills/algolia-search-implementation",
+        "./skills/algolia-data-modeling",
+        "./skills/algolia-index-configuration",
+        "./skills/algolia-ui-libraries",
+        "./skills/algolia-instantsearch-ui",
+        "./skills/algolia-autocomplete",
+        "./skills/algolia-events-insights",
+        "./skills/algolia-neuralsearch",
+        "./skills/algolia-agent-studio",
+        "./skills/algolia-release-qa"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@
 | `algolia-crawler` | Crawl web pages or whole sites into a RAG-optimized index with the Algolia Crawler |
 | `algolia-quickstart` | Create an Algolia account and provision an application (App ID / API key) via the CLI |
 
+### Implementation planning suite (`algolia-implementation`)
+
+A companion bundle that plans, sequences, and validates Algolia implementations end to end. It routes live operations to `algolia-cli` / `algolia-mcp` / `algobot-cli` and code-level UI work to `instantsearch`. Install as a bundle — `algolia-discovery-planning` is the entry point and loads the companion skills per phase.
+
+| Skill                          | Description                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| `algolia-discovery-planning`   | Entry point: maps any request to lifecycle phases and loads companion skills   |
+| `algolia-search-implementation`| Execution checklist and readiness signposts for net-new builds                 |
+| `algolia-data-modeling`        | Record shape, variants, objectID, facets, and event-attribution readiness      |
+| `algolia-index-configuration`  | Relevance settings, ranking, synonyms, rules, replicas, rollback planning      |
+| `algolia-ui-libraries`         | Living selector for current Algolia UI libraries and docs paths                |
+| `algolia-instantsearch-ui`     | Customer-readiness layer for InstantSearch results/browse experiences          |
+| `algolia-autocomplete`         | Source strategy, selection contracts, and QA for autocomplete/suggestions      |
+| `algolia-events-insights`      | Click/conversion/view event taxonomy, queryID and userToken guidance           |
+| `algolia-neuralsearch`         | NeuralSearch readiness, rollout planning, evaluation, and measurement          |
+| `algolia-agent-studio`         | Agent Studio planning, readiness gates, guardrails, and launch validation      |
+| `algolia-release-qa`           | Launch QA with severity-led findings, event checks, and residual risk          |
+
 ---
 
 ## 🚀 Installation

--- a/skills/algolia-agent-studio/SKILL.md
+++ b/skills/algolia-agent-studio/SKILL.md
@@ -20,7 +20,7 @@ Use this skill for Agent Studio work after confirming the product goal and the q
 - When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
 - Do not require custom Academy/docs access; use customer-provided sources only as optional context.
 - When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
-- Produce a launch recommendation: launch, limited pilot, fix first, or do not start.
+- Produce a launch recommendation: launch, limited rollout, fix first, or do not start.
 - Start the first agent with one narrow, high-intent job and the smallest tool/data surface that can solve it; breadth comes after evidence.
 
 ## Official Companion Skills
@@ -60,7 +60,7 @@ Ask the smallest useful subset before building:
 - What LLM provider, model, region, latency, and cost constraints apply?
 - What analytics, feedback, event, or conversion signals define success?
 - What domains, auth model, and API-key boundaries are required?
-- Which one high-intent user task should the pilot solve, and what requests are deliberately out of scope?
+- Which one high-intent user task should the first rollout solve, and what requests are deliberately out of scope?
 - Which entry point best matches that task: search AI mode, chat widget, side panel, embedded assistant, or prompt suggestion?
 - For each enabled tool, what triggers it, what data/arguments may it use, what result does the user see, and what happens on timeout or refusal?
 
@@ -82,7 +82,7 @@ Ask the smallest useful subset before building:
 ## Anti-Patterns
 
 - Starting with prompts before defining tools, permissions, data boundaries, and success measures.
-- Giving a client-facing agent write-capable tools before a read-only pilot has been validated.
+- Giving a client-facing agent write-capable tools before a read-only rollout has been validated.
 - Relying on prompt instructions as the only guardrail for sensitive data or consequential actions.
 - Shipping without approved domains, authentication review, fallback/handoff behavior, and feedback measurement.
 - Treating Agent Studio as separate from search relevance, event quality, or index permissions.

--- a/skills/algolia-agent-studio/SKILL.md
+++ b/skills/algolia-agent-studio/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: algolia-agent-studio
+description: >
+  Product-specific Algolia Agent Studio implementation, validation, and optimization guidance. Use when planning, building, integrating, or auditing Agent Studio agents, AI-powered conversational experiences, LLM provider setup, Algolia Search tools, client-side tools, MCP tools, memory, prompting, conversations, turn context, caching, analytics, feedback, authentication, approved domains, guardrails, or tool security. Do NOT use for live Agent Studio configuration, dry runs, publish/deploy actions, or config-as-code operations; use the official algobot-cli skill instead. Do NOT use for generic non-Algolia RAG or chatbot architecture unless Agent Studio is the target product.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.4"
+---
+
+# Algolia Agent Studio
+
+Use this skill for Agent Studio work after confirming the product goal and the quality of the underlying Algolia data, events, and search configuration. Agent Studio experiences are only as good as the tools, records, guardrails, and measurement loops they can rely on.
+
+## Customer-Facing Standard
+
+- Define the agent contract before setup: purpose, audience, tools, allowed actions, guardrails, escalation, and measurement.
+- Treat data, events, permissions, and tool security as prerequisites, not follow-up polish.
+- Use public `academy.algolia.com` for learning alignment and public `algolia.com/doc` for current implementation guidance when source-backed context is needed.
+- When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
+- Do not require custom Academy/docs access; use customer-provided sources only as optional context.
+- When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
+- Produce a launch recommendation: launch, limited pilot, fix first, or do not start.
+- Start the first agent with one narrow, high-intent job and the smallest tool/data surface that can solve it; breadth comes after evidence.
+
+## Official Companion Skills
+
+- Use official `algobot-cli` for Agent Studio setup, agent config-as-code, tools, memory, conversations, dry runs, and deploy/publish workflows.
+- Use official `algolia-mcp` for live search, analytics, recommendations, and index inspection that inform the agent's tools.
+- Use official `algolia-cli` for index, settings, rules, synonyms, or record changes the agent depends on.
+- Use this skill after the official tool call to produce the agent contract, readiness gates, security checks, event/feedback plan, and launch recommendation.
+
+## Source-Of-Truth Rules
+
+- Use official `algobot-cli` and current Agent Studio docs for commands, config fields, provider behavior, completions endpoints, tool configuration, memory, analytics, feedback, and deploy/publish steps.
+- Do not invent Agent Studio capabilities, endpoint URLs, tool permissions, or memory behavior.
+- If the official tool or docs cannot confirm a behavior, label it as an assumption and recommend a dry run or dashboard verification.
+
+## Workflow
+
+1. Read `references/agent-studio-guide.md` before implementation or review.
+2. Read `references/example-output.md` when producing an agent contract or customer-facing launch recommendation.
+3. Start with `$algolia-discovery-planning` if business goal, audience, channel, or success metric is unclear.
+4. Use `$algolia-data-modeling` and `$algolia-index-configuration` when the agent will retrieve Algolia records or answer from search results.
+5. Use `$algolia-events-insights` when the experience needs analytics, feedback, personalization, Recommend, NeuralSearch optimization, or conversion measurement.
+6. Use `$algolia-release-qa` before launch, especially for guardrails, approved domains, authentication, tool security, and event coverage.
+7. Map the agent's room: instructions, tools, retrieval, data access, memory/context, safety, provider, and entry point. Diagnose behavior against that map before blaming the model.
+8. Teach the setup as a lifecycle: create and configure, preview and test, publish and integrate, then refine with Conversations and Analytics.
+
+## Questions To Ask
+
+Ask the smallest useful subset before building:
+
+- What job should the agent perform: discovery, product advice, support, shopping assistant, internal operations, merchandising, or content navigation?
+- Which entry point will users see first: search bar AI mode, autocomplete, side panel, InstantSearch Chat Widget, embedded assistant, or prompt suggestions?
+- Which Algolia indices, tools, or external systems may the agent use?
+- Which user attributes, session state, turn context, or memory are allowed?
+- Which actions are read-only versus write/action-taking?
+- What should the agent refuse, escalate, or hand off?
+- What LLM provider, model, region, latency, and cost constraints apply?
+- What analytics, feedback, event, or conversion signals define success?
+- What domains, auth model, and API-key boundaries are required?
+- Which one high-intent user task should the pilot solve, and what requests are deliberately out of scope?
+- Which entry point best matches that task: search AI mode, chat widget, side panel, embedded assistant, or prompt suggestion?
+- For each enabled tool, what triggers it, what data/arguments may it use, what result does the user see, and what happens on timeout or refusal?
+
+## Implementation Standards
+
+- Define the agent contract before code: purpose, audience, tools, allowed actions, guardrails, escalation paths, and measurement.
+- Treat Quick Setup or templates as starting points, not launch readiness. Review instructions, Search tool settings, memory, prompt suggestions, guardrails, rate limits, cost controls, approved domains, and integration snippet before recommending publish.
+- Treat Algolia Search tools as product APIs. Confirm index readiness, filters, searchable attributes, ranking, secured keys, and returned fields.
+- Never expose admin keys, unrestricted actions, internal-only data, or unreviewed external tools to a client-facing agent.
+- Keep prompts grounded in business policy and available tools. Avoid prompts that imply access to data or actions the agent cannot actually use.
+- Instrument feedback and conversion loops early; AI product tuning without events becomes anecdotal.
+- Validate failure modes: no results, ambiguous user intent, unavailable items, policy refusal, tool errors, auth failures, and slow LLM/tool responses.
+- Use Conversations for qualitative review before relying on aggregate analytics. Look for unclear instructions, bad follow-up behavior, weak retrieval, inappropriate fallback, and guardrail misses.
+- Use Analytics as a feedback loop, not a vanity dashboard. Let usage, token/cost patterns, search usage, feedback, and outcome signals drive configuration changes.
+- Define each enabled tool as a contract: trigger, allowed parameters, access scope, confirmation requirement, user-visible result, failure response, and measurement event.
+- Treat memory as intentional product behavior. Enable it for authenticated, multi-turn value; document identity, retention, consent, and what must never be retained. Do not assume dashboard enablement alone creates safe end-to-end memory.
+- Choose the entry point by user moment. Search-side AI helps query refinement and retrieval; a conversational surface supports multi-turn help; prompt suggestions should lead only to tasks the agent can actually complete.
+
+## Anti-Patterns
+
+- Starting with prompts before defining tools, permissions, data boundaries, and success measures.
+- Giving a client-facing agent write-capable tools before a read-only pilot has been validated.
+- Relying on prompt instructions as the only guardrail for sensitive data or consequential actions.
+- Shipping without approved domains, authentication review, fallback/handoff behavior, and feedback measurement.
+- Treating Agent Studio as separate from search relevance, event quality, or index permissions.
+- Publishing immediately after the preview gives one good answer.
+- Treating Conversations as support logs only; they are the fastest way to identify bad instructions, weak retrieval, missing data, and fallback failures.
+- Expanding a first agent into a broad assistant before one high-intent, read-only workflow has reliable retrieval, tool use, fallback, and measurement.
+- Blaming the selected LLM before checking scope, instructions, tools, retrieval, data access, memory/context, safety, and integration state.
+
+## Academy And Customer Education Alignment
+
+When source-backed guidance is needed, search public Academy sources for Agent Studio and AI-readiness learning objectives and public Algolia docs for setup, tools, events, security, and current product behavior. Use source guidance procedurally, not as copied documentation. Map the request to a customer maturity level and one or more use-case bundles, then provide customer-facing setup, validation, and optimization guidance.
+
+## Maturity Behavior
+
+- Beginner implementation: define the agent job, audience, data sources, and simplest safe read-only flow before tool expansion.
+- Production readiness: validate authentication, approved domains, tool boundaries, API keys, fallback behavior, event coverage, handoff paths, and the agent-room troubleshooting trace.
+- Optimization: add feedback loops, conversation analytics, tool-result quality review, and measured prompt/tool iteration.
+- AI readiness: require clean searchable data, reliable events, permission-aware tools, security review, and a clear launch or fix-first recommendation.
+
+## Output Contract
+
+For implementation, return an agent contract, agent-room map, tool contracts, entry-point choice, setup steps, integration code or configuration, event/feedback plan, security notes, QA cases, and a post-launch refinement loop. For audits, lead with launch blockers and the data/event/tool dependencies that must be fixed first.

--- a/skills/algolia-agent-studio/agents/openai.yaml
+++ b/skills/algolia-agent-studio/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia Agent Studio"
+  short_description: "Implement and validate Agent Studio"
+  default_prompt: "Use $algolia-agent-studio to plan, implement, and validate an Algolia Agent Studio experience."

--- a/skills/algolia-agent-studio/evals/evals.json
+++ b/skills/algolia-agent-studio/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "algolia-agent-studio",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We want an AI shopping assistant for our wine store using Agent Studio. Ideas so far: it should recommend wines, answer region/pairing questions, manage the user's cart, apply discount codes, update account details, and escalate to support. We have a solid wines_prod index and decent events. Where do we start - can you write the system prompt?",
+      "expected_output": "The response does not start with the prompt: it defines the agent contract first (purpose, audience, tools, allowed actions, guardrails, escalation, measurement) and pushes back on the broad scope, recommending one narrow, high-intent, read-only pilot job (e.g. wine discovery/pairing advice from the wines_prod Search tool) with cart/discount/account write actions deliberately out of scope until the read-only pilot is validated. It defines each enabled tool as a contract (trigger, allowed parameters, access scope, user-visible result, failure response, measurement event), covers guardrails, approved domains, auth, API-key boundaries, and feedback/analytics loops, and routes actual config-as-code, dry runs, and publish operations to the official algobot-cli.",
+      "files": [],
+      "expectations": [
+        "Refuses to start with prompt writing alone; defines an agent contract (purpose, audience, tools, allowed actions, guardrails, escalation, measurement) first",
+        "Narrows the pilot to one high-intent, read-only job and explicitly defers write-capable actions (cart management, discount codes, account updates) until the read-only pilot is validated",
+        "Defines tool contracts for the Search tool: trigger, allowed parameters/filters, data scope, user-visible result, and failure/timeout behavior",
+        "Covers security prerequisites: approved domains, authentication, API-key boundaries, and never exposing admin keys or unreviewed tools to a client-facing agent",
+        "Plans feedback, analytics, or conversion measurement from the start rather than as post-launch polish",
+        "Routes live Agent Studio configuration, dry runs, and publish/deploy steps to the official algobot-cli rather than performing them via this skill"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Our Agent Studio support agent (published 3 weeks ago on our docs site) keeps giving vague answers and sometimes says it 'can't find anything' even for topics we definitely have articles on. The team's conclusion is the LLM we picked is just bad and we should switch providers. Agree?",
+      "expected_output": "The response does not accept the blame-the-model conclusion: it maps the agent's room (instructions, tools, retrieval, data access, memory/context, safety, provider, entry point) and diagnoses against that map first, since 'can't find anything' for existing content usually indicates weak retrieval — Search tool configuration, index readiness, filters, searchable attributes, or returned fields. It recommends qualitative review of Conversations before aggregate analytics to spot unclear instructions, weak retrieval, and bad fallback behavior, uses live inspection via algolia-mcp/algobot-cli for evidence, and only considers a provider switch after the room is ruled out.",
+      "files": [],
+      "expectations": [
+        "Declines to blame the LLM provider first; walks the agent-room map (instructions, tools, retrieval, data access, memory/context, safety, entry point) before considering a model switch",
+        "Identifies the 'can't find anything' symptom as likely a retrieval/Search-tool problem (index readiness, filters, searchable attributes, returned fields) to verify",
+        "Recommends reviewing Conversations qualitatively to find unclear instructions, weak retrieval, or fallback failures before relying on aggregate analytics",
+        "Routes live inspection (agent config, index/search behavior) to algobot-cli, algolia-mcp, or algolia-cli for evidence",
+        "Produces a diagnosis or validation plan rather than an immediate configuration rewrite, and labels unconfirmed behavior as assumptions to verify with a dry run or dashboard check"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Pre-launch review: our internal ops agent is configured with our admin API key so it can 'do everything', memory is on because the toggle was there, there's no approved-domains list yet, and we tested it once in preview where it answered great. Dev wants to publish today. Green light?",
+      "expected_output": "The response does not green-light: it leads with launch blockers — an admin API key exposed to an agent (never expose admin keys or unrestricted actions), memory enabled without intent/identity/retention/consent decisions, missing approved domains and auth review, and publishing after a single good preview answer (a named anti-pattern). It requires failure-mode validation (no results, ambiguous intent, tool errors, refusal behavior), an event/feedback plan, and returns a clear fix-first recommendation with the security items as prerequisites, routing config changes through algobot-cli.",
+      "files": [],
+      "expectations": [
+        "Refuses to approve launch and leads with the launch blockers rather than a positive summary",
+        "Flags the admin API key as a blocker: agents must not get admin keys or unrestricted action scope",
+        "Flags memory-by-default as a blocker: memory must be intentional with identity, retention, and consent decisions documented",
+        "Flags missing approved domains and authentication review as launch prerequisites",
+        "Calls out publishing after one good preview answer as insufficient and requires failure-mode QA (no results, ambiguous intent, tool errors, refusals)",
+        "Issues an explicit recommendation from the skill's set (launch, limited pilot, fix first, do not start) — here fix-first or equivalent"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-agent-studio/evals/evals.json
+++ b/skills/algolia-agent-studio/evals/evals.json
@@ -4,11 +4,11 @@
     {
       "id": 1,
       "prompt": "We want an AI shopping assistant for our wine store using Agent Studio. Ideas so far: it should recommend wines, answer region/pairing questions, manage the user's cart, apply discount codes, update account details, and escalate to support. We have a solid wines_prod index and decent events. Where do we start - can you write the system prompt?",
-      "expected_output": "The response does not start with the prompt: it defines the agent contract first (purpose, audience, tools, allowed actions, guardrails, escalation, measurement) and pushes back on the broad scope, recommending one narrow, high-intent, read-only pilot job (e.g. wine discovery/pairing advice from the wines_prod Search tool) with cart/discount/account write actions deliberately out of scope until the read-only pilot is validated. It defines each enabled tool as a contract (trigger, allowed parameters, access scope, user-visible result, failure response, measurement event), covers guardrails, approved domains, auth, API-key boundaries, and feedback/analytics loops, and routes actual config-as-code, dry runs, and publish operations to the official algobot-cli.",
+      "expected_output": "The response does not start with the prompt: it defines the agent contract first (purpose, audience, tools, allowed actions, guardrails, escalation, measurement) and pushes back on the broad scope, recommending one narrow, high-intent, read-only rollout job (e.g. wine discovery/pairing advice from the wines_prod Search tool) with cart/discount/account write actions deliberately out of scope until the read-only rollout is validated. It defines each enabled tool as a contract (trigger, allowed parameters, access scope, user-visible result, failure response, measurement event), covers guardrails, approved domains, auth, API-key boundaries, and feedback/analytics loops, and routes actual config-as-code, dry runs, and publish operations to the official algobot-cli.",
       "files": [],
       "expectations": [
         "Refuses to start with prompt writing alone; defines an agent contract (purpose, audience, tools, allowed actions, guardrails, escalation, measurement) first",
-        "Narrows the pilot to one high-intent, read-only job and explicitly defers write-capable actions (cart management, discount codes, account updates) until the read-only pilot is validated",
+        "Narrows the rollout to one high-intent, read-only job and explicitly defers write-capable actions (cart management, discount codes, account updates) until the read-only rollout is validated",
         "Defines tool contracts for the Search tool: trigger, allowed parameters/filters, data scope, user-visible result, and failure/timeout behavior",
         "Covers security prerequisites: approved domains, authentication, API-key boundaries, and never exposing admin keys or unreviewed tools to a client-facing agent",
         "Plans feedback, analytics, or conversion measurement from the start rather than as post-launch polish",
@@ -39,7 +39,7 @@
         "Flags memory-by-default as a blocker: memory must be intentional with identity, retention, and consent decisions documented",
         "Flags missing approved domains and authentication review as launch prerequisites",
         "Calls out publishing after one good preview answer as insufficient and requires failure-mode QA (no results, ambiguous intent, tool errors, refusals)",
-        "Issues an explicit recommendation from the skill's set (launch, limited pilot, fix first, do not start) — here fix-first or equivalent"
+        "Issues an explicit recommendation from the skill's set (launch, limited rollout, fix first, do not start) — here fix-first or equivalent"
       ]
     }
   ]

--- a/skills/algolia-agent-studio/references/agent-studio-guide.md
+++ b/skills/algolia-agent-studio/references/agent-studio-guide.md
@@ -1,0 +1,207 @@
+# Agent Studio Guide
+
+## Current Docs To Verify
+
+The Algolia docs navigation checked on 2026-07-22 lists Agent Studio under AI-powered experiences with these areas:
+
+- Get started: quickstart, dashboard, LLM providers, integration.
+- Extend: tools overview, Algolia Search tool, Algolia Recommend tool, Display Results tool, client-side tools, MCP tools, memory.
+- Customize: prompting, conversations, turn context, caching, analytics, feedback, experimental features.
+- Security: user authentication, approved domains, guardrails, tool security.
+- Reference: agent configuration.
+
+Verify current docs before changing live configuration:
+
+- https://www.algolia.com/doc/guides/algolia-ai/agent-studio
+- https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/quickstart
+- https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/integration
+- https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/tools/algolia-search
+- https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/analytics
+- https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/feedback
+- https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/guardrails
+
+Current public docs position Agent Studio as a beta feature. Treat setup, launch recommendations, endpoint behavior, and production commitments as docs-verified before implementation.
+
+## Agent Contract
+
+Define:
+
+- User and business goal.
+- Entry point and channel.
+- Available Algolia indices and external tools.
+- Allowed read actions.
+- Allowed write/action-taking actions.
+- Authentication and user context.
+- Guardrails and refusal policy.
+- Escalation and handoff behavior.
+- Analytics, feedback, and conversion measurement.
+- Rollback or kill-switch plan.
+
+## Academy Setup Flow
+
+Teach Agent Studio as more than prompt setup. A good agent is scoped, connected to the right data, constrained by safety settings, integrated into the right user moment, and refined through real usage.
+
+Use this customer-friendly sequence:
+
+1. Choose Quick Setup or a template that matches the experience type.
+2. Define scoped instructions: job, audience, tone, boundaries, and what to do when context is missing.
+3. Connect the Search tool or other approved tools.
+4. Review agent-specific search settings for the connected index or indices.
+5. Decide whether memory, turn context, prompt suggestions, or AI mode entry points are appropriate.
+6. Configure safety controls: custom guardrails, fallback responses, rate limits, cost controls, and approved domains.
+7. Preview with happy path, ambiguous, out-of-scope, no-result, and blocked scenarios.
+8. Publish only after readiness gates pass.
+9. Integrate with the generated snippet, AI mode entry points, prompt suggestions, InstantSearch Chat Widget, or framework-specific integration.
+10. Refine with Conversations and Analytics.
+
+Agent behavior comes from the full configuration: instructions, tools, data, search settings, memory, safety controls, integration context, and feedback loops.
+
+## The Agent Room
+
+Use this map to define scope and diagnose unexpected behavior. An agent can only work with what is available in its configured room.
+
+| Room component | Define | Review when behavior is weak |
+| --- | --- | --- |
+| Scope and instructions | Job, audience, boundaries, clarifying questions, refusal, and handoff. | Is the task in scope and is the instruction specific enough? |
+| Tools | Enabled tools, triggers, allowed arguments, action boundaries, and user-visible output. | Does the agent actually have the required tool and a clear reason to call it? |
+| Retrieval and search settings | Connected indices, required filters, returned fields, ranking/retrieval behavior. | Did the tool retrieve useful, permission-safe records for the task? |
+| Data and context | Index access, frontend turn context, authenticated context, and allowed fields. | Was the needed data connected and available at runtime? |
+| Memory | Identity, retention, consent, recall purpose, and prohibited information. | Did the task require durable prior context, and was it safely implemented? |
+| Safety and operations | Guardrails, fallback, rate/cost limits, domains, auth, and ownership. | Was the request blocked, limited, escalated, or handled safely? |
+| Provider and entry point | Provider/model constraints and the UI moment where the user meets the agent. | Is the experience appropriate for the job and is the integration passing context correctly? |
+
+The model generates language. It does not grant access to data, tools, memory, or actions that are absent from this room.
+
+## Start Narrow, Then Expand
+
+Start the first release with one high-intent job, a read-only tool surface, and a short list of representative user tasks. Good candidates include guided product discovery, policy/support retrieval, or documentation navigation.
+
+State what the pilot does not handle. Expand only after Conversations show reliable retrieval and behavior, Analytics shows the experience is used as intended, and the team can attribute outcomes.
+
+## Data And Search Readiness
+
+Before an Agent Studio implementation depends on Algolia Search tools:
+
+- Confirm target indices have stable objectIDs, useful display fields, semantic text fields, and access-control fields.
+- Confirm searchable attributes, custom ranking, synonyms, rules, filters, and replicas match the assistant journey.
+- Confirm secured keys or filters prevent cross-user, cross-account, region, or permission leaks.
+- Confirm the agent can explain or cite retrieved records when the product experience requires it.
+- Confirm no hidden/internal attributes are exposed in tool responses or prompts.
+
+## Tool And Entry-Point Contracts
+
+For every tool, record its contract before enabling it.
+
+| Contract field | Define |
+| --- | --- |
+| Trigger | What user intent should cause the tool to run? |
+| Inputs and constraints | Which parameters, filters, and returned fields are allowed or always applied? |
+| Authority | Is it read-only, a safe client UI action, or a consequential action requiring confirmation? |
+| User outcome | What does the user see after the result: answer, record link, updated UI state, handoff, or refusal? |
+| Failure path | What happens for no result, timeout, auth failure, invalid input, or unavailable service? |
+| Measurement | Which tool, click, conversion, feedback, or handoff event proves it helped? |
+
+Choose the entry point by user moment:
+
+- Search AI mode or filter suggestions for query refinement within search.
+- Chat widget or embedded assistant for multi-turn discovery, support, or comparison.
+- Side panel for contextual help without interrupting the main task.
+- Prompt suggestions only for supported follow-ups the agent can retrieve or perform.
+
+Use current docs and the official implementation skill for exact widget, API, and tool configuration details.
+
+## Readiness Gates
+
+Do not treat Agent Studio as ready until these gates pass:
+
+1. Data gate: target indices have stable objectIDs, useful display fields, permission-safe returned attributes, and records that match the agent's job.
+2. Relevance gate: search tools return acceptable results for representative user tasks, including ambiguous, low-result, and no-result cases.
+3. Events gate: feedback, clicks, conversions, or resolution outcomes are instrumented well enough to evaluate the agent.
+4. Security gate: approved domains, authentication, tool permissions, guardrails, and least-privilege credentials are validated.
+5. Operations gate: fallback, handoff, rollback, cost/latency expectations, and ownership are defined.
+
+If one gate fails, report it as a blocker or explicit assumption before recommending launch.
+
+## Conversations And Analytics Review
+
+Before launch, use preview and test conversations to answer:
+
+- Did the agent understand the user's job and ask clarifying questions when needed?
+- Did the Search tool retrieve useful records for the task?
+- Did the response stay grounded in retrieved data and approved policy?
+- Did guardrails or fallback responses trigger for unsafe, out-of-scope, or unsupported requests?
+- Did the agent handle no results, low confidence, unavailable items, tool errors, and follow-up turns?
+
+After deployment, use Analytics as a refinement loop:
+
+- Total conversations and trend.
+- Search/tool usage.
+- Token usage, latency, and cost.
+- Positive/negative feedback.
+- Fallback, handoff, or abandonment patterns.
+- Conversions or resolved outcomes when instrumented.
+
+Recommended loop: user interactions -> Conversations/Analytics insight -> configuration adjustment -> targeted retest -> measured improvement.
+
+### Troubleshooting Trace
+
+When an answer is incomplete, unsafe, or wrong, diagnose in this order:
+
+1. Request and scope: should this agent handle the request?
+2. Instructions: did they define the role, boundary, and clarification behavior?
+3. Tools: was the required tool enabled and described clearly enough to be selected?
+4. Retrieval: did the tool query the right index with the right filters and return useful records?
+5. Data/context: was the required record, authenticated context, or frontend turn context available?
+6. Memory: did the task require prior context, and was it intentionally enabled and implemented?
+7. Safety/fallback: did the guardrail, confirmation, or escalation path work as designed?
+8. Provider/integration: only then review model/provider limits, latency, transport, or rendering behavior.
+
+Record the broken link and retest the original scenario plus one adjacent edge case after each change.
+
+## Events And Feedback
+
+Plan events early:
+
+- Search or tool result impressions when useful.
+- Clicks on records, recommendations, or suggested actions.
+- Conversions such as add-to-cart, purchase, lead, save, support resolution, or content completion.
+- Explicit feedback such as thumbs up/down, reason codes, comments, and escalation.
+- Conversation-level outcomes such as abandoned, resolved, handed off, or converted.
+
+Use stable event names and preserve userToken/session identity when the same experience also powers search, NeuralSearch, personalization, or Recommend.
+
+## Tooling Guardrails
+
+- Start read-only unless the use case clearly needs actions.
+- Require explicit user confirmation before consequential actions.
+- Scope client-side tools to safe UI actions.
+- Scope MCP or server tools with least-privilege credentials.
+- Validate arguments before tool execution.
+- Handle tool timeouts and errors with user-safe responses.
+- Never let prompt text be the only protection for sensitive or write-capable tools.
+
+## QA Checklist
+
+- Happy path and ambiguous intent.
+- No results and low-confidence retrieval.
+- Tool error and slow response.
+- Authenticated and unauthenticated flows.
+- Out-of-scope or unsafe requests.
+- Prompt injection in user text and retrieved content.
+- Cross-tenant/account/region access boundaries.
+- Feedback and analytics payloads.
+- LLM provider, model, latency, and cost assumptions.
+- Approved domains and deployment environment.
+- Prompt suggestions route users into supported tasks instead of broad, unanswerable requests.
+- Entry points match user intent: search bar AI mode, autocomplete, side panel, embedded assistant, or chat widget.
+- Existing agents using older Search tooling are reviewed before relying on newer agent-specific search settings.
+- One high-intent pilot job, its deliberately out-of-scope requests, and the selected entry point are documented.
+- Each enabled tool has a trigger, constrained inputs, authority, user outcome, failure path, and measurement event.
+- Memory is enabled only with a documented identity, retention, consent, and safe-use plan.
+
+## Related Skills
+
+- `$algolia-data-modeling`: index and record readiness.
+- `$algolia-index-configuration`: relevance and filters.
+- `$algolia-events-insights`: events, userToken, feedback, conversions.
+- `$algolia-release-qa`: security and launch checks.

--- a/skills/algolia-agent-studio/references/agent-studio-guide.md
+++ b/skills/algolia-agent-studio/references/agent-studio-guide.md
@@ -76,7 +76,7 @@ The model generates language. It does not grant access to data, tools, memory, o
 
 Start the first release with one high-intent job, a read-only tool surface, and a short list of representative user tasks. Good candidates include guided product discovery, policy/support retrieval, or documentation navigation.
 
-State what the pilot does not handle. Expand only after Conversations show reliable retrieval and behavior, Analytics shows the experience is used as intended, and the team can attribute outcomes.
+State what the rollout does not handle. Expand only after Conversations show reliable retrieval and behavior, Analytics shows the experience is used as intended, and the team can attribute outcomes.
 
 ## Data And Search Readiness
 
@@ -195,7 +195,7 @@ Use stable event names and preserve userToken/session identity when the same exp
 - Prompt suggestions route users into supported tasks instead of broad, unanswerable requests.
 - Entry points match user intent: search bar AI mode, autocomplete, side panel, embedded assistant, or chat widget.
 - Existing agents using older Search tooling are reviewed before relying on newer agent-specific search settings.
-- One high-intent pilot job, its deliberately out-of-scope requests, and the selected entry point are documented.
+- One high-intent rollout job, its deliberately out-of-scope requests, and the selected entry point are documented.
 - Each enabled tool has a trigger, constrained inputs, authority, user outcome, failure path, and measurement event.
 - Memory is enabled only with a documented identity, retention, consent, and safe-use plan.
 

--- a/skills/algolia-agent-studio/references/example-output.md
+++ b/skills/algolia-agent-studio/references/example-output.md
@@ -15,11 +15,11 @@ Help shoppers compare products, narrow choices, and answer product-availability 
 
 ## Agent Room Map
 
-| Component | Pilot decision |
+| Component | Rollout decision |
 | --- | --- |
 | Scope | Compare products and narrow choices; exclude account, order, delivery, warranty, and regulated advice. |
 | Retrieval | Use the product index with region and availability filters. |
-| Memory | Do not enable for the first single-session pilot. |
+| Memory | Do not enable for the first single-session rollout. |
 | Safety | Refuse unsupported claims and hand off account-specific questions. |
 | Entry point | Product-discovery chat surface for multi-turn comparison. |
 
@@ -33,7 +33,7 @@ Help shoppers compare products, narrow choices, and answer product-availability 
 
 ## Tool Contract
 
-| Field | Product search pilot |
+| Field | Product search rollout |
 | --- | --- |
 | Trigger | A user asks to find, compare, or narrow products. |
 | Constraints | Apply approved availability and region filters; return only safe display fields. |
@@ -64,7 +64,7 @@ Help shoppers compare products, narrow choices, and answer product-availability 
 
 ## Launch Recommendation
 
-Status: limited pilot.
+Status: limited rollout.
 
 Launch to a controlled audience after validating product filters, event payloads, fallback states, and approved-domain/security configuration. Do not broaden rollout until feedback and conversion events are visible.
 

--- a/skills/algolia-agent-studio/references/example-output.md
+++ b/skills/algolia-agent-studio/references/example-output.md
@@ -1,0 +1,77 @@
+# Example Output: Agent Studio Contract
+
+Use this shape before implementation or launch review.
+
+## Agent Purpose
+
+Help shoppers compare products, narrow choices, and answer product-availability questions using approved Algolia search results. The agent may recommend products and explain tradeoffs, but it must not invent inventory, discounts, delivery promises, or warranty terms.
+
+## Audience And Channel
+
+- Audience: ecommerce shoppers.
+- Channel: web product discovery experience.
+- Primary goal: increase confident product selection and add-to-cart.
+- Secondary goal: reduce unsupported product questions.
+
+## Agent Room Map
+
+| Component | Pilot decision |
+| --- | --- |
+| Scope | Compare products and narrow choices; exclude account, order, delivery, warranty, and regulated advice. |
+| Retrieval | Use the product index with region and availability filters. |
+| Memory | Do not enable for the first single-session pilot. |
+| Safety | Refuse unsupported claims and hand off account-specific questions. |
+| Entry point | Product-discovery chat surface for multi-turn comparison. |
+
+## Allowed Tools And Data
+
+| Tool or source | Allowed use | Guardrail |
+| --- | --- | --- |
+| Product search index | Retrieve product candidates, filters, availability, and product attributes. | Apply region, availability, and account filters before presenting results. |
+| Product detail URL | Link users to product pages. | Do not claim availability unless the result includes it. |
+| Conversation context | Use stated preferences such as budget, size, activity, or style. | Do not store sensitive data unless the implementation explicitly supports it. |
+
+## Tool Contract
+
+| Field | Product search pilot |
+| --- | --- |
+| Trigger | A user asks to find, compare, or narrow products. |
+| Constraints | Apply approved availability and region filters; return only safe display fields. |
+| Authority | Read-only retrieval. |
+| User outcome | Explain tradeoffs and link to supported product records. |
+| Failure path | Ask one clarifying question, offer a safe fallback, or hand off when retrieval cannot answer. |
+| Measurement | Tool use, product click, add-to-cart, feedback, fallback, and handoff events. |
+
+## Required Readiness Checks
+
+- Data records include useful titles, categories, descriptions, attributes, price, availability, and URLs.
+- Secured or restricted records cannot appear for unauthorized users.
+- Instructions are scoped to the agent's job and include what to do when the answer depends on context.
+- Agent-specific search settings are reviewed for the connected index.
+- Prompt suggestions and entry points lead to supported tasks.
+- Search events and feedback events are defined before optimization.
+- Fallback behavior exists for no results, ambiguous intent, unavailable products, and tool errors.
+- The agent refuses requests outside its job, such as medical, legal, warranty, or account-specific claims unless approved tools support them.
+
+## Measurement Plan
+
+| Signal | Purpose |
+| --- | --- |
+| Product clicked from agent recommendation | Measures whether suggestions are useful. |
+| Add to cart after agent interaction | Measures product-discovery impact. |
+| Positive or negative feedback | Flags answer quality and tool issues. |
+| No-result or fallback turns | Reveals data, relevance, or prompt gaps. |
+
+## Launch Recommendation
+
+Status: limited pilot.
+
+Launch to a controlled audience after validating product filters, event payloads, fallback states, and approved-domain/security configuration. Do not broaden rollout until feedback and conversion events are visible.
+
+## Refinement Loop
+
+1. Review five to ten real Conversations before reading aggregate metrics.
+2. Label issues as instruction problem, search/retrieval problem, data gap, guardrail/fallback problem, or integration/event problem.
+3. Use Analytics to confirm whether the issue is isolated or recurring.
+4. Make one configuration change at a time.
+5. Retest the original conversation pattern and one adjacent edge case before expanding rollout.

--- a/skills/algolia-autocomplete/SKILL.md
+++ b/skills/algolia-autocomplete/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: algolia-autocomplete
+description: >
+  Build and review Algolia Autocomplete and query suggestion experiences. Use when planning or implementing typeahead, query suggestions, recent searches, popular searches, federated autocomplete panels, product/content suggestions, detached mobile mode, plugins, keyboard navigation, insights events, or Autocomplete integration with InstantSearch. For net-new search or ecommerce builds, start with algolia-discovery-planning, which loads algolia-search-implementation so source strategy, data contract, and event taxonomy decisions are visible before autocomplete is marked ready. Do NOT use for full search results pages, browse pages, filters, pagination, or current refinements; use algolia-instantsearch-ui instead. Do NOT use for choosing between Algolia UI libraries; use algolia-ui-libraries. Do NOT use as the source of truth for current Autocomplete package APIs; use the official instantsearch skill and current docs alongside this customer-readiness skill.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.5"
+---
+
+# Algolia Autocomplete
+
+Use this skill for search-as-you-type experiences where the user has not committed to a full search results page yet. Autocomplete should help users form intent, not just mirror final results.
+
+## Customer-Facing Standard
+
+- Define source strategy and selection behavior before code.
+- Validate keyboard, touch, mobile, empty/loading states, routing handoff, and events before launch.
+- Use public `academy.algolia.com` for learning alignment and public `algolia.com/doc` for current implementation guidance when source-backed context is needed.
+- When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
+- Do not require custom Academy/docs access; use customer-provided sources only as optional context.
+- When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
+- Produce source ordering, selection contract, implementation notes, and QA checklist.
+- Assess the finished experience as helpful, clear, focused, device-usable, and accessible; a technically connected panel is not necessarily ready for users.
+
+## Official Companion Skills
+
+- Use official `instantsearch` for current Autocomplete implementation details, framework-specific source-of-truth checks, and code-level patterns.
+- Use official `algolia-mcp` when live index schema, query suggestions, facet values, or analytics should shape source selection.
+- Use this skill before the official implementation skill to frame the customer journey, and after it to validate source strategy, selection behavior, mobile behavior, and event handoff.
+
+## Source-Of-Truth Rules
+
+- Use the official `instantsearch` skill or current docs for Autocomplete package APIs, plugins, render hooks, and InstantSearch integration details.
+- Do not assume a Query Suggestions index exists; verify it or design a fallback source strategy.
+- Do not wire selection behavior until the destination is known: submit query, navigate, refine InstantSearch, apply filter, open record, or run an approved action.
+- For net-new implementations, confirm the data contract and event taxonomy, or create minimal provisional versions and name the follow-up decisions.
+- Treat mouse, touch, Enter, and keyboard navigation as equivalent routes: each selection must reach the same URL or state with the same query and applicable scope.
+
+## Workflow
+
+1. Read `references/autocomplete-guide.md` before implementation or review.
+2. Confirm whether Autocomplete is standalone, integrated with InstantSearch, or part of a federated search entry point.
+3. Confirm the data contract for every direct-result source: index, display fields, URLs, objectIDs, and event attribution fields.
+4. Confirm the event taxonomy for every selection type, especially the difference between direct-result clicks and query suggestion submissions.
+5. Choose sources intentionally: query suggestions, products, categories, content, recent searches, popular searches, or redirects.
+6. Teach the difference between source types: Query Suggestions help users search better; product/content results help users jump directly to a record; recent searches help returning users resume.
+7. Write a source contract for each group: trigger, source/index, input value, selection destination, scope carried forward, and attribution method.
+8. Select advanced patterns only when they solve a named user need: resumption, discovery, early narrowing, non-product intent, or no-result recovery.
+9. Validate suggestion quality before connecting it to the UI.
+10. Implement in layers: mount the base input, validate Query Suggestions, add direct results, add focus/empty-query behavior, then validate mobile and events.
+11. Use the official `instantsearch` skill and current docs to implement the selected package, plugin, renderer, or InstantSearch integration.
+12. Implement keyboard, mouse, touch, empty, loading, and detached mobile behavior.
+13. Preserve event attribution from suggestion selection to the resulting search or conversion.
+
+## Questions To Ask
+
+- What should appear while typing: queries, products, categories, content, recent searches, or all of these?
+- Should selecting a suggestion navigate, refine InstantSearch state, open a result, or submit a query?
+- Is there a query suggestions index, and how is it generated?
+- Are the suggestions clear, useful, searchable, and free of internal/test language?
+- What should appear before typing: recent searches, popular searches, useful categories, shortcuts, or nothing?
+- Are recent searches stored locally, server-side, or disabled?
+- What mobile behavior is expected?
+- Which selections need click or conversion events?
+- If a category is shown with a suggestion, does it narrow the subsequent search, route to a category page, or only provide context?
+- What should a user see and be able to do when a source is empty, slow, or unavailable?
+- Which user problem justifies each advanced pattern: resuming, discovering, narrowing, reaching non-product content, or recovering from a likely dead end?
+- With the mobile keyboard open, which few suggestions or direct results must remain visible, and where does “see all results” lead?
+
+## Implementation Standards
+
+- Use Algolia Autocomplete primitives and plugins instead of hand-rolled typeahead state unless the project has a strong reason.
+- Keep source limits tight and ordered by user value.
+- Keep Query Suggestions and product/content results visually and behaviorally distinct.
+- Review the Query Suggestions index before launch. Tune noisy, incomplete, offensive, stale, or internal suggestions before exposing them.
+- Use recent searches and `openOnFocus` style behavior only when the empty-query state helps users resume or discover, not as a promotional dumping ground.
+- Debounce or stall UI responsibly; do not make the input feel laggy.
+- Respect accessibility defaults and avoid custom markup that breaks keyboard navigation.
+- Keep InstantSearch integration explicit: update query/refinements without creating conflicting state loops.
+- Use consistent userToken and event metadata when suggestions lead to result interactions.
+- Use a URL or selection-state contract that works for pointer and keyboard selection; test it with a category-bearing suggestion where relevant.
+- Keep a source empty-state deliberate: hide a failed/empty group, show an approved fallback, or show a clear no-suggestions state. Do not leave blank labeled panels.
+- Start with a small source set and add groups only when they pass the helpful, clear, and focused test; do not let a new source displace the best guidance.
+- On mobile, preserve a top search input, distinct clear and close actions, tap-friendly rows, visible primary guidance above the keyboard, and a clear path to all results.
+- Keep category scope sparse and visually distinct. Use it to narrow a genuinely ambiguous query, not as a duplicate list of category labels.
+
+## Anti-Patterns
+
+- Showing too many source groups or too many hits per group.
+- Treating autocomplete as a mini search results page instead of a search guidance experience.
+- Connecting Query Suggestions before reviewing whether suggestions are useful, safe, and likely to return results.
+- Using the source index name where the Query Suggestions plugin expects the Query Suggestions index name.
+- Making every suggestion behave differently without clear visual or routing cues.
+- Creating two competing query states between Autocomplete and InstantSearch.
+- Breaking keyboard, focus, Escape, Enter, or detached mobile behavior with custom markup.
+- Sending direct-result events as search-attributed events when the item did not come from an Algolia search response with queryID.
+- Displaying a category label without defining whether it scopes the result, navigates, or is informational only.
+- Letting the pointer path and keyboard path produce different query parameters, filters, or destinations.
+- Adding popular searches, categories, federated content, or product groups because the panel has space rather than because they solve a named user need.
+- Letting product cards crowd out the query guidance, especially when the mobile keyboard is open.
+- Combining the clear-input action and the close-overlay action on mobile.
+
+## Completion Checkpoints
+
+Before calling autocomplete ready, or when handing off a prototype with follow-ups, state whether these checkpoints are satisfied, deferred, or unknown:
+
+- Source and ordering contract.
+- Selection behavior for every source.
+- Referenced data contract or explicit minimal demo data contract for direct-result sources.
+- Referenced event taxonomy or explicit user-approved event deferral.
+- Clear distinction between query suggestion submissions and direct-result clicks.
+- Browser QA for keyboard, pointer, touch, detached mobile mode, empty/loading states, selection behavior, and routing/search-state handoff.
+- Source contract and fallback behavior for unavailable, empty, or low-quality suggestions.
+- Quality standard verdict: helpful, clear, focused, device-usable, and accessible, with any failed dimension recorded as a follow-up.
+
+## Academy And Customer Education Alignment
+
+When source-backed guidance is needed, search public Academy sources for autocomplete and search UX learning objectives and public Algolia docs for autocomplete, query suggestions, UI state, mobile behavior, and event attribution. Use source guidance to shape questions, maturity level, use-case bundle, and validation artifacts; do not turn it into a static docs dump.
+
+## Maturity Behavior
+
+- Beginner implementation: define sources, ordering, and selection behavior before adding advanced plugins.
+- Production readiness: build and verify the base input, Query Suggestions, direct results, empty-query behavior, then keyboard, touch, mobile detached mode, routing handoff, accessibility, and event attribution.
+- Optimization: review suggestion quality, no-result behavior, source ordering, recent/popular searches, category scope, federated content, latency, and query suggestion analytics.
+- AI readiness: preserve selected query/result context, userToken, and downstream event attribution for personalization, NeuralSearch evaluation, or AI assistants.
+
+## Output Contract
+
+Return code or review notes plus:
+
+- Official Skill Usage Note: framework/package choice and official source consulted for implementation details.
+- Source Contract: order, trigger, source/index, input value, selection destination, carried scope, fallback, and event treatment for each group.
+- Customer UI Plan: empty/focus behavior, mobile mode, result-page handoff, device-specific content budget, and accessibility notes.
+- Quality Standard: helpful, clear, focused, device-usable, and accessible verdicts with open issues.
+- QA checklist for keyboard navigation, selection behavior, mobile detached mode, routing/search-state sync, no suggestions, latency, and events.

--- a/skills/algolia-autocomplete/agents/openai.yaml
+++ b/skills/algolia-autocomplete/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia Autocomplete"
+  short_description: "Build autocomplete and query suggestion UIs"
+  default_prompt: "Use $algolia-autocomplete to build or review an Algolia Autocomplete experience."

--- a/skills/algolia-autocomplete/evals/evals.json
+++ b/skills/algolia-autocomplete/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "algolia-autocomplete",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Adding autocomplete to our cookware shop header. Stack is vanilla JS with @algolia/autocomplete-js. I want query suggestions plus a few product hits with images. Main index is cookware_products - I assume the suggestions just come from there too? Selecting a product should go to its PDP, selecting a suggestion should run the search.",
+      "expected_output": "The response corrects the assumption that suggestions come from the main index: it verifies whether a Query Suggestions index exists (they are separate, generated indices) or designs a fallback source strategy, and warns against putting the source index name where the plugin expects the Query Suggestions index name. It writes a source contract per group (trigger, source/index, input value, selection destination, carried scope, event treatment), keeps source limits tight and Query Suggestions visually/behaviorally distinct from product hits, defines the two selection behaviors (navigate to PDP vs submit query), distinguishes direct-result click events from query suggestion submissions, and defers exact package APIs to the official instantsearch skill or current docs. It ends with a QA checklist covering keyboard, touch, mobile detached mode, and empty/loading states.",
+      "files": [],
+      "expectations": [
+        "Does not assume a Query Suggestions index exists; verifies it or designs a fallback, and distinguishes it from the cookware_products source index",
+        "Produces a source contract for each group covering trigger, source/index, input value, selection destination, and event treatment",
+        "Defines distinct selection behavior for products (navigate to PDP) versus suggestions (submit query), and keeps the two source types visually/behaviorally distinct",
+        "Distinguishes direct-result click events from query suggestion submissions in the event plan, and does not send search-attributed events without a valid queryID",
+        "Defers Autocomplete package API details to the official instantsearch skill or current docs rather than asserting them from memory",
+        "Includes a QA checklist covering keyboard navigation, touch/mobile detached mode, empty/loading states, and selection routing"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Our mobile autocomplete panel is a mess. When the keyboard opens you see 2 giant product cards and nothing else - no suggestions visible, and users keep hitting the X thinking it clears the text but it closes the whole overlay. PM wants to ALSO add popular searches, categories, and a blog articles section to the panel. Help.",
+      "expected_output": "The response treats mobile as a first-class constraint: with the keyboard open, primary query guidance must remain visible above the keyboard, so product cards must not crowd out suggestions; the clear-input and close-overlay actions must be separate controls (it flags the combined X as a named anti-pattern). It pushes back on adding popular searches, categories, and articles just because the panel has space — each new source must pass the helpful/clear/focused test and solve a named user need — and recommends a tight device-specific content budget with a clear path to all results. It ends with a mobile QA checklist and a quality-standard verdict.",
+      "files": [],
+      "expectations": [
+        "Recommends keeping primary query guidance (suggestions) visible above the open mobile keyboard rather than letting product cards crowd it out",
+        "Identifies combining the clear-input action and close-overlay action as an anti-pattern and recommends distinct controls",
+        "Pushes back on adding popular searches, categories, and blog articles simultaneously; requires each source to solve a named user need rather than filling panel space",
+        "Recommends tight source limits or a device-specific content budget, with a visible path to see all results",
+        "Assesses or plans to assess the experience against the quality standard: helpful, clear, focused, device-usable, accessible",
+        "Provides a mobile-focused QA checklist (keyboard, touch targets, detached mode, clear vs close behavior)"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Weird bug report: on our travel site autocomplete (React, integrated with InstantSearch results page below), clicking a suggestion with the mouse gives different results than highlighting it with arrow keys and pressing Enter - the keyboard path seems to drop the 'destination' category scope. Also sometimes the panel shows an empty 'Hotels' section header with nothing under it.",
+      "expected_output": "The response treats mouse, touch, and keyboard selection as equivalent routes that must reach the same URL/state with the same query and scope, diagnosing the dropped category scope as a selection-contract bug — the input value/selection destination must be defined per source and tested with a category-bearing suggestion for both pointer and keyboard paths. For the empty Hotels group, it applies the deliberate empty-state standard: hide a failed/empty group, show an approved fallback, or show a clear no-suggestions state, never a blank labeled panel. It also checks the InstantSearch integration for competing query states and defers code-level API fixes to the official instantsearch skill.",
+      "files": [],
+      "expectations": [
+        "States that pointer and keyboard selection must produce the same query parameters, filters/scope, and destination, and identifies the dropped category scope as a selection-contract defect",
+        "Recommends testing the selection contract with a category-bearing suggestion across mouse, touch, and keyboard paths",
+        "Addresses the empty 'Hotels' header with a deliberate empty-state rule: hide the empty group, show a fallback, or show a clear no-suggestions state — not a blank labeled section",
+        "Checks for or warns about competing query states between Autocomplete and InstantSearch integration",
+        "Defers exact package/API-level fixes to the official instantsearch skill or current docs"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-autocomplete/references/autocomplete-guide.md
+++ b/skills/algolia-autocomplete/references/autocomplete-guide.md
@@ -1,0 +1,228 @@
+# Autocomplete Guide
+
+## Official Skill Bridge
+
+Use the official `instantsearch` skill and current Algolia docs as the implementation authority. This guide owns the customer-facing choices that determine whether an autocomplete is useful and verifiable.
+
+| Use the official skill/docs for | Use this skill for |
+| --- | --- |
+| Package APIs, supported framework patterns, renderers, plugins, code-level integrations, and installed-library checks. | Source strategy, customer journey, selection and URL contract, mobile behavior, attribution handoff, and QA. |
+| Current Autocomplete or InstantSearch integration details. | Whether a source should exist, what it means to the user, when it appears, and what happens after selection. |
+
+Work in this sequence: frame the journey and source contracts here, implement with the official skill/docs, then return here for customer-readiness QA.
+
+## Academy Experience Quality Standard
+
+Use this review before calling an Autocomplete experience ready. Passing an API smoke test alone is insufficient.
+
+| Check | Pass when | Typical failure |
+| --- | --- | --- |
+| Helpful | Each visible item helps complete, improve, narrow, resume, or redirect a search. | Internal terms, generic noise, or content with no next-step value. |
+| Clear | A user can distinguish a suggested search, direct record, category scope, recent search, or page. | Unlabeled federated groups or mixed selection behavior without cues. |
+| Focused | The panel prioritizes the most useful few choices. | A mini results page, excessive source groups, or product cards overwhelming suggestions. |
+| Device-usable | The best guidance remains usable with the mobile keyboard open and stays close to the input on desktop. | Hidden suggestions, tiny touch targets, or needless internal scrollbars. |
+| Accessible | Pointer, touch, and keyboard users get equivalent navigation, destinations, and visible active states. | Enter opens a different path than click, or focus feedback is unclear. |
+
+Ask the practical question: “Does this help the user take the next step?” Do not add a source merely because it can be technically connected.
+
+## Experience Design
+
+Autocomplete should help users express intent. Decide whether the panel should show:
+
+- Query suggestions.
+- Products or records.
+- Categories.
+- Content results.
+- Recent searches.
+- Popular searches.
+- Actions or shortcuts.
+- Redirects.
+- Multiple federated sources.
+
+Order sources by user value and keep each source small enough for fast scanning.
+
+## Source Contract
+
+Define the following before implementation. A source that cannot complete this contract is not ready to expose.
+
+| Source | Appears when | Uses | Fills input with | Selection outcome | Carries forward | Event treatment |
+| --- | --- | --- | --- | --- | --- | --- |
+| Query suggestions | User types, and optionally on focus | Query Suggestions index | Suggested query | Submit or route to results | Query and, if selected, approved category scope | Result-page interactions are attributed to the resulting search. |
+| Product/content hits | User types | Primary or federated index | Usually the record label, only if continuing search | Open the record | Record URL and any required context | Send a click only when the source response provides search attribution. |
+| Category suggestion | User types or focus state | Static, facet, or Query Suggestions category data | Query if present | Route to a category page or scoped search | Explicit category/filter state | Attribute the resulting search, then downstream interactions. |
+| Recent search | Focus or empty query | Approved local or server-side history | Prior query | Resubmit or route to prior search | Query and any retained, safe scope | Treat the subsequent results search as the attribution origin. |
+| Redirect/action | Exact approved condition | Rules or static source | Depends on action | Navigate or execute the approved action | Only declared parameters | Track as a navigation/action, not a fabricated search click. |
+
+For every source, define the same outcome for mouse, touch, Enter, and keyboard navigation. If a source renders a link, ensure its URL encodes the same query and scope used by the selection handler.
+
+## Journey-To-Pattern Selector
+
+Choose advanced patterns in response to a user problem, not as a feature checklist.
+
+| User need | Prefer | Guardrail |
+| --- | --- | --- |
+| Resume an earlier task | Recent searches in the empty-query state. | Confirm storage and privacy expectations; keep the list short. |
+| Find a starting point before typing | Popular searches, useful categories, or approved shortcuts. | Keep it helpful rather than promotional. |
+| Narrow an ambiguous broad query | Category scope. | Show only one or two meaningful scopes and carry the chosen scope into the result. |
+| Reach policies, FAQs, stores, or support | Federated content source. | Label the content type and make the destination predictable. |
+| Avoid a likely no-result dead end | Better query suggestions, alternatives, or a relevant non-product path. | Do not imply a result exists when it does not. |
+
+## Content Budget By Device
+
+Use the Academy ranges as a starting point, then validate with real content and the actual viewport rather than treating them as a fixed product rule.
+
+| Surface | Starting budget | Layout standard |
+| --- | --- | --- |
+| Mobile | About 4-7 query suggestions and only the strongest few direct results. | Use a focused overlay, keep the input at the top, make rows easy to tap, and retain a visible “see all results” path above the keyboard. |
+| Desktop | About 6-10 query suggestions with a small adjacent or following direct-result group. | Keep the panel visually connected to the input, label groups, show hover/focus state, and avoid a needless internal scrollbar. |
+
+Keep the input-clear action separate from closing a mobile overlay. They solve different user intentions.
+
+## Academy Mental Model
+
+Use this distinction when explaining or reviewing autocomplete:
+
+- Query Suggestion: "Here is something useful to search for."
+- Product or content result: "Here is a record you may want to open."
+- Recent search: "Here is something you already started."
+- Autocomplete: the full search-box experience that can combine those sources.
+
+A good autocomplete experience reduces effort before the user commits to a results page. It should help the user ask a better question, resume a prior search, or jump directly to a useful record without overwhelming them.
+
+## Query Suggestions Readiness
+
+Before connecting Query Suggestions to Autocomplete, verify:
+
+- The source index is the index users actually search.
+- The Query Suggestions index exists and is not confused with the source index.
+- Suggestions are generated from useful search behavior, approved external suggestions, or facet values.
+- Minimum letters and minimum hits are configured to avoid vague or low-value suggestions.
+- Banned words or exclusions remove offensive, internal, test, stale, or irrelevant terms.
+- Sample suggestions are clear, useful, searchable, clean, and likely to return worthwhile results.
+
+If suggestions are noisy, fix the Query Suggestions configuration before polishing the UI.
+
+### Category-Bearing Suggestions
+
+Categories are useful only when their role is unambiguous. Choose one:
+
+- Scope: carry the selected category into the results-page filter or InstantSearch state.
+- Destination: route to a category landing page with the selected query.
+- Context only: show the category as a label and do not imply filtering.
+
+Do not show a category merely because it is available in the source data. Test the URL or state handoff with a real category-bearing suggestion and confirm that keyboard selection behaves exactly like pointer selection.
+
+For a compact category-scope experience, show only one or two strong scopes, distinguish them from ordinary query suggestions, and phrase them as a scope, such as “in Women's Running.” Avoid repeating the typed query as a separate category item.
+
+## Selection Behavior
+
+For each source, define what selection does:
+
+- Submit a query.
+- Navigate to a search results page.
+- Update InstantSearch UI state.
+- Navigate directly to a record.
+- Apply a category/filter.
+- Execute an action.
+
+Do not leave selection behavior implicit; this is where many autocomplete implementations feel broken.
+
+Suggested defaults:
+
+- Query Suggestions usually submit or navigate to a search query.
+- Product/content results usually navigate directly to a record.
+- Category suggestions usually apply a scope/filter or navigate to a category page.
+- Recent searches usually resubmit the prior query.
+- Federated support/content results should use labels and destinations that make their source obvious.
+
+Different sources can have different selection behavior, but the visual design must make the difference clear.
+
+## Focus, Empty, And Failure States
+
+The zero-query panel is part of the experience, not leftover space. Choose one intentional behavior:
+
+- Keep the panel closed until the user types.
+- Open with recent searches when resumption is valuable and storage is appropriate.
+- Open with approved popular searches, categories, or shortcuts when they help discovery.
+
+For every visible group, decide what happens when it is empty, slow, or unavailable. Hide empty groups cleanly, use an approved fallback where it preserves user value, and avoid blank headings or stale items. A stalled indicator should acknowledge delay without preventing users from continuing to type or submit.
+
+### No-Result Guidance
+
+Autocomplete should prevent dead ends where it can. When a query has weak product intent or is likely to fail, prefer a better suggested query, a useful category, an approved non-product result, or an explicit route to all search results. Keep the guidance truthful: do not turn an unavailable product query into an unrelated direct-result list.
+
+## Implementation Guardrails
+
+- Use Autocomplete's `getSources` model and plugins when possible.
+- Use `getAlgoliaResults` for Algolia-backed sources.
+- Preserve keyboard navigation, focus management, and accessible labels.
+- Test detached mobile behavior when enabled.
+- Avoid returning too many hits per source.
+- Debounce and loading states should make latency understandable without blocking typing.
+- When integrated with InstantSearch, keep query state synchronization one-way or carefully controlled to avoid loops.
+- Prefer the library's accessible generated input and item URL behavior unless the official implementation guidance calls for a custom renderer.
+- Keep the source contract in code comments or implementation notes so a later source change does not silently change routing or attribution.
+
+## Event And Analytics Notes
+
+- Track suggestion clicks and direct-result clicks according to the downstream analytics needs.
+- Preserve userToken across autocomplete and the search/results page.
+- If a suggestion leads to a search results page, ensure the resulting search can still generate queryID-attributed events.
+- If a direct product result is clicked from autocomplete, choose the event method that accurately reflects whether the item came from an Algolia query.
+- Do not infer queryID attribution for a static, recent, redirect, or otherwise non-search source. Preserve the source type so the event plan stays honest.
+
+## Integration Handoff
+
+For a separate results page, define the route parameters and verify the page reads them into its search state. For same-page InstantSearch, define the single owner of query and refinement state, then verify an Autocomplete selection updates it without a duplicate search loop.
+
+For federated results, label the source and make the destination predictable. A user should be able to tell whether Enter opens a product, searches a query, scopes a category, or navigates to a different content surface.
+
+## Staged Implementation And Review
+
+Build and verify in layers. This avoids spending time on templates or complex federation before the foundations are real:
+
+1. Mount the generated Autocomplete input in an empty container and confirm it accepts focus and typing.
+2. Connect and review Query Suggestions with realistic user prefixes; fix noisy source data before display polish.
+3. Add a small direct-result source, distinct label, required display fields, and a keyboard-safe destination.
+4. Add open-on-focus content only when the empty-query journey has a purpose; validate recent searches and popular suggestions separately.
+5. Validate detached/mobile behavior with the keyboard open, then run the quality standard and event handoff QA.
+
+Use official docs and the official implementation skill for current package and plugin syntax at each layer.
+
+## QA
+
+- Keyboard navigation: arrow keys, Enter, Escape, Tab.
+- Mouse and touch selection.
+- Empty query behavior.
+- No suggestions behavior.
+- Multiple source ordering and labels.
+- Mobile detached mode.
+- Slow network and stalled search indicator.
+- Integration with URL routing or InstantSearch state.
+- Pointer and keyboard selection produce the same URL or search state.
+- Category-bearing suggestions either carry their intended scope or are clearly context-only.
+- Query Suggestions use the Query Suggestions index, not the source index.
+- Suggestion text is shopper/user-friendly, not internal or test language.
+- Mobile layout remains usable when the keyboard is open.
+- Each empty, slow, or unavailable source has intentional behavior with no blank labeled panel.
+- The quality standard passes: helpful, clear, focused, device-usable, and accessible.
+- Mobile keeps the top input and strongest guidance visible with the keyboard open; clear and close actions are distinct.
+
+## Review Output Template
+
+Return these sections when planning or auditing:
+
+1. Official Skill Usage Note: framework/package and current implementation authority.
+2. Source Contract: source order, trigger, selection destination, scope handoff, fallback, and event treatment.
+3. Customer UI Plan: focus/empty behavior, mobile mode, labels, and direct-result versus query-submission cues.
+4. Data and Event Readiness: required record fields, URLs, objectIDs, userToken continuity, and queryID boundaries.
+5. QA: keyboard, pointer, touch, mobile, routing/state, latency, no-suggestions, and attribution checks.
+
+## Source Notes
+
+- Autocomplete is a production-ready JavaScript library for building autocomplete experiences: https://www.algolia.com/doc/ui-libraries/autocomplete/introduction/what-is-autocomplete
+- Autocomplete sources can include static terms, Algolia results, recent searches, and other sources, while the developer controls rendering: https://www.algolia.com/doc/ui-libraries/autocomplete/introduction/what-is-autocomplete
+- Autocomplete does not provide the same ready-made UI widget set as InstantSearch; it provides behavior and accessibility primitives while the implementation controls rendering: https://www.algolia.com/doc/ui-libraries/autocomplete/introduction/what-is-autocomplete
+- Get started with Autocomplete: use `@algolia/autocomplete-js` for the standard renderer; use the core package only when a custom renderer is genuinely needed. Autocomplete generates an accessible input from a container, while item URLs support direct keyboard access: https://www.algolia.com/doc/ui-libraries/autocomplete/introduction/getting-started
+- Query Suggestions can carry category data; define how the category is applied to same-page state or a routed results URL: https://www.algolia.com/doc/ui-libraries/autocomplete/guides/adding-suggested-searches
+- Official plugins cover recent searches, Query Suggestions, Algolia Insights, tags, and redirect URLs. Confirm the current API in docs before coding: https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/plugins

--- a/skills/algolia-data-modeling/SKILL.md
+++ b/skills/algolia-data-modeling/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: algolia-data-modeling
+description: >
+  Algolia data modeling and indexing guidance. Use before or alongside indexing records or building Algolia search UI for net-new search, browse, autocomplete, ecommerce, personalization, Dynamic Re-Ranking, recommendations, or analytics-aware implementations. Makes record shape, objectID, display fields, facets, ranking fields, and event attribution explicit decisions. Use for records, variants, SKUs, indices, replicas, searchable and faceting attributes, denormalization, merchandising fields, timestamps, inventory, event attribution, indexing pipelines, partial updates, secured data, multi-language or multi-region strategies, and migrations. Do NOT use for live imports, exports, record mutations, settings changes, or account actions; use algolia-cli or algolia-mcp. Do NOT use for frontend UI implementation; use algolia-instantsearch-ui, algolia-autocomplete, algolia-ui-libraries, or the official instantsearch skill.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.5"
+---
+
+# Algolia Data Modeling
+
+Use this skill to shape the data before code writes records to Algolia. Good relevance usually starts with records that match the user journey, not the source database schema.
+
+## Customer-Facing Standard
+
+- Ask for sample records and edge cases before making record-shape claims.
+- State assumptions plainly when source data is missing.
+- Use public `academy.algolia.com` for learning alignment and public `algolia.com/doc` for current implementation guidance when source-backed context is needed.
+- When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
+- Do not require custom Academy/docs access; use customer-provided sources only as optional context.
+- When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
+- Produce an indexing contract, validation queries, owner handoff, and reindex/update path.
+- For ecommerce catalogs, explicitly choose between variant-level, variation-group-level, and product-level record models before discussing merchandising or UI behavior.
+
+## Official Companion Skills
+
+- Use official `algolia-mcp` or `algolia-cli` when live sample records, existing index shape, object counts, imports, or exports need to be inspected.
+- Use this skill after the official tool call to turn findings into a customer-facing indexing contract, variant strategy, and validation plan.
+
+## Source-Of-Truth Rules
+
+- Do not infer a final record model from database tables alone. Require sample records, UI expectations, event needs, and update ownership.
+- Do not prescribe exact Algolia settings, API commands, or migration steps without routing live operations through official `algolia-cli`, `algolia-mcp`, or current docs.
+- Treat any schema without stable IDs, variant ownership, timestamp ownership, inventory strategy, and event identifiers as provisional.
+- Before indexing records or starting UI implementation, create or update an index contract when practical. If the user needs a quick prototype, proceed with a minimal provisional contract and list the assumptions to revisit.
+- Do not treat merchandising rules as a substitute for missing merchandising data. Newness, sale status, brand ownership, inventory, best-seller status, margin, and popularity must be explicit fields or documented upstream computations.
+
+## Index Contract Decision Point
+
+Before indexing or UI work, create `algolia/index-contract.md` or an equivalent artifact when practical. If you proceed without a complete contract, call out which decisions are provisional:
+
+- Index names.
+- Record model: variant-level, variation-group-level, product-level, or non-commerce equivalent.
+- Record granularity.
+- `objectID` strategy.
+- Searchable attributes.
+- Displayed attributes.
+- Faceting attributes.
+- Ranking signals.
+- Ranking metric grain, order, direction, precision, and bucket logic.
+- Merchandising fields.
+- Inventory fields.
+- Event attribution fields.
+- Update owner and cadence.
+- Validation queries.
+
+For demos and prototypes, produce a one-paragraph data contract, three validation queries, and explicit deferred production concerns.
+
+## Workflow
+
+1. Read `references/data-modeling-guide.md` before making data-shape decisions.
+2. Read `references/example-output.md` when producing a customer-facing indexing contract or showing what good output looks like.
+3. Ask for context if record granularity, business goal, or filtering requirements are unknown.
+4. Design the index contract first: index names, environments, objectID strategy, record shape, searchable attributes, faceting attributes, ranking signals, and update ownership.
+5. Choose the variant strategy before writing code: product record, variant record, grouped variants, or separate records by locale, region, tenant, channel, price list, or permission set.
+6. Run a merchandising data-gap check before indexing: schema clarity, timestamps/newness, promo attributes, inventory buckets, best-seller buckets, margin/popularity metrics, metric precision, and upstream ownership.
+7. Prefer denormalized, search-ready records. Avoid forcing the UI to join or infer critical ranking/filtering fields at query time.
+8. Design custom ranking inputs as business tie-breakers, not raw database dumps. Decide which metrics matter first, whether higher or lower is better, and whether values should be rounded or bucketed so later ranking attributes can still influence ties.
+9. Include a migration and reindexing plan when changing objectIDs, record granularity, or settings that affect relevance.
+10. Teach business users that many merchandising issues are data readiness issues first. Rules and boosts cannot reliably promote new, sale, own-brand, high-inventory, high-margin, popular, or best-selling products if those concepts are not represented in the indexed records.
+
+## Questions To Ask
+
+Ask the smallest useful subset:
+
+- Can you share 5 normal records and 5 edge cases, including variants, unavailable items, restricted content, regional differences, or records that often search poorly?
+- What entity should a search result represent: product, variant, SKU, article, location, account, or another unit?
+- Should variants appear as separate hits, one hit per product, one hit per shared variation such as color, grouped choices inside one hit, or filtered silently by availability, channel, region, account, or permissions?
+- What attributes must users search, filter, sort, display, or use for ranking?
+- Which attributes must merchandising use to promote or suppress products: new, rating, sales, popularity, margin, on sale, own brand, high inventory, best seller, seasonal, campaign, or editorial priority?
+- How does the business define "new", "high inventory", and "best selling" per category, and where are those buckets calculated before indexing?
+- Which custom ranking metrics should act first, second, and third when text relevance ties: sales, margin, rating, popularity, freshness, inventory, or editorial priority?
+- Are ranking metrics too precise for useful tie-breaking, and should they be rounded or bucketed such as `sales_30d_bucket`, `margin_band`, or `freshness_bucket`?
+- Which attributes are stable identifiers versus volatile display or ranking fields?
+- What records should be hidden, delayed, or secured by user/account/region/channel?
+- How often do records change, and which system owns those changes?
+- Does the same content need separate indices for locales, regions, tenants, environments, or user segments?
+
+## Implementation Standards
+
+- Treat `objectID` as a stable contract. Do not derive it from mutable display fields.
+- Make variant modeling explicit. Do not accidentally index one source row per SKU if users expect one product result, and do not collapse variants if color, size, availability, price, region, or permissions materially change search behavior.
+- Keep record size intentional: include fields needed for retrieval, ranking, faceting, display, analytics context, and event attribution.
+- Separate production, staging, and development indices. Do not test destructive indexing against production.
+- Use replicas for alternate sort orders and virtual replicas for relevant sorting when appropriate.
+- Preserve queryID/objectID/position compatibility for events when shaping UI responses.
+- Do not require exact stock counts in Algolia for merchandising unless there is a clear operational reason. Prefer stable buckets or booleans such as `in_stock`, `stock_bucket`, or `high_inventory` so every sale does not force unnecessary reindexing.
+- Calculate category-specific freshness, high-inventory, sale, own-brand, and best-seller flags upstream before indexing. Do not expect Algolia rules to infer missing business definitions from incomplete records.
+- Explain continuous values versus buckets. Exact sales, margin, inventory, or timestamp values can be useful, but buckets often make merchandising and custom ranking easier to reason about and less noisy.
+- Treat custom ranking as ordered tie-breaking after textual relevance. If the first ranking metric is highly precise, later metrics may rarely matter; reduce precision or bucket values when the business expects a second or third metric to participate.
+- For ecommerce, preserve the difference between product identity, variation identity, and SKU identity. Use parent IDs and selected-variant fields when the UI must show one family result while events or filters still need variant-level truth.
+
+## Anti-Patterns
+
+- Indexing one row per SKU by default when the shopper expects one product family.
+- Collapsing variants when availability, price, permissions, color, size, or event attribution must differ by variant.
+- Using exact inventory counts as a merchandising input when buckets would satisfy the business need with fewer updates.
+- Promoting "new" products without a reliable timestamp or explicit newness attribute.
+- Promoting "best sellers" without a defined time window, category scope, and refresh owner.
+- Ranking by raw sales, margin, rating, or popularity without deciding the business order, direction, time window, category scope, and precision.
+- Using a highly precise first custom ranking metric that prevents later business metrics from resolving ties.
+- Adding display-only or internal fields to searchable text because they are convenient in the source system.
+- Designing events after the record contract, causing `objectID`, `index`, `queryID`, or variant aggregation problems later.
+
+## Pre-Indexing Checkpoints
+
+Before indexing records, state whether these items are ready, provisional, or deferred:
+
+- `objectID` stability.
+- Facets used by the UI and their normalization.
+- Ranking fields and why they matter.
+- Ranking metric precision: raw, rounded, bucketed, or curated.
+- Retrievable display fields.
+- Image, URL, title, price, availability, or other UI-required fields.
+- Event attribution fields.
+- Inventory, availability, or permissions fields needed by the UI.
+- Update owner and cadence for volatile fields.
+
+## Ecommerce Record Model Strategy
+
+Choose one of these patterns and state the tradeoff:
+
+- Variant-level records: one record represents a specific sellable variation such as a color/size SKU. Use when users search, filter, compare, price, or convert at the variant level; when color/size/availability/image must be exact; or when granular updates matter. Plan grouping or distinct behavior if the UI should show product families.
+- Variation-group-level records: one record groups variants that share a key attribute such as color. Use when the UI and merchandising usually operate at a product/color level, but filters and images still need more precision than a master product record.
+- Product-level or master-product records: one record represents the base product and contains all variants. Use when merchandising, analytics, and AI behavior should operate at product level and users expect one product result. Document any frontend work needed to show the right variant after filters.
+- Locale, region, channel, or account variants: split into separate records or indices when text, price, availability, permissions, or events differ enough to change search behavior.
+- Secured variants: never rely on UI hiding alone. Permission-sensitive variants need secured filters, separate indices, or record-level access strategy.
+
+For each model, state the impact on textual relevance, faceting accuracy, merchandising control, AI/personalization behavior, analytics aggregation, update cost, record count, and UI complexity.
+
+## Academy And Customer Education Alignment
+
+When source-backed guidance is needed, search public Academy sources for indexing and data-readiness learning objectives and public Algolia docs for records, objectID, facets, replicas, and current implementation details. Map the customer to beginner implementation, production readiness, optimization, or AI readiness. Use source context to guide decisions and questions; do not paste long course or docs excerpts.
+
+## Maturity Behavior
+
+- Beginner implementation: produce the simplest correct record contract and ask only for sample records, source owner, objectID candidates, required filters, and primary ranking goals.
+- Production readiness: add environment naming, update ownership, secured fields, rollback/reindex plan, and validation queries.
+- Optimization: add ranking signals, query analytics, replica strategy, and controlled relevance tests.
+- AI readiness: validate semantic fields, event attribution fields, permissions, noisy attributes, and whether NeuralSearch or Agent Studio prerequisites are met.
+
+## Deliverables
+
+For design work, return a concise index contract with sample records, record model strategy, merchandising data-gap report, custom ranking metric map, and validation queries. For code work, implement the contract and include the reindex/update path plus validation commands or tests.

--- a/skills/algolia-data-modeling/agents/openai.yaml
+++ b/skills/algolia-data-modeling/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia Data Modeling"
+  short_description: "Model records and indices for Algolia"
+  default_prompt: "Use $algolia-data-modeling to design Algolia records, indices, replicas, and indexing workflows."

--- a/skills/algolia-data-modeling/evals/evals.json
+++ b/skills/algolia-data-modeling/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "algolia-data-modeling",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "we're moving our shopify catalog (~40k SKUs, apparel, sizes/colors as variants) into algolia and I don't know if each variant should be its own record or if I should index one record per product. Shoppers filter by size and color a lot, and availability differs per size. What's the right call?",
+      "expected_output": "The response asks for sample records / edge cases (or states assumptions plainly), then makes the variant strategy an explicit decision: it walks through variant-level vs variation-group-level vs product-level records, recommends a model fit for size/color filtering with per-size availability (typically variant or color-group records with a shared parent field and distinct/grouping so the UI shows one product family), and states the tradeoffs for faceting accuracy, record count, update cost, analytics aggregation, and UI complexity. It also covers objectID stability, event attribution fields, and proposes an index contract with validation queries.",
+      "files": [],
+      "expectations": [
+        "Asks for sample records and edge cases, or explicitly states assumptions when proceeding without them",
+        "Explicitly compares variant-level, variation-group-level, and product-level record models rather than asserting one option without alternatives",
+        "Recommends a grouping/distinct strategy on a shared parent field when suggesting variant-level or group-level records, and explains the tradeoff (faceting/availability accuracy vs record count, update cost, dedup behavior)",
+        "Notes that per-size availability and size/color filtering argue against collapsing everything into one product record",
+        "Treats objectID as a stable identifier not derived from mutable display fields",
+        "Proposes an index contract (or minimal provisional contract) with items such as searchable/facet/display attributes, event attribution fields, and validation queries"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Our merchandiser wants 'new arrivals' and 'best sellers' boosted in search results. Our product records in the products_prod index are basically a dump of our ERP table - no timestamps, no sales data on the records. She keeps asking me to just add a Rule in the dashboard. What do I tell her?",
+      "expected_output": "The response reframes this as a data readiness problem first: rules and boosts cannot reliably promote 'new' or 'best-selling' products if those concepts are not represented as explicit fields. It runs a merchandising data-gap check, asks how the business defines 'new' and 'best seller' (time window, category scope, refresh owner), recommends computing those flags/buckets upstream before indexing (e.g. freshness bucket, best-seller bucket rather than raw counts), explains buckets vs precise values for custom ranking tie-breaking, and defers any live rule/settings writes to algolia-cli or algolia-mcp.",
+      "files": [],
+      "expectations": [
+        "States that merchandising rules cannot substitute for missing merchandising data, and that newness/best-seller status must be explicit indexed fields or documented upstream computations",
+        "Asks how the business defines 'new' and 'best selling' (time window, category scope) and who owns the refresh/update cadence",
+        "Recommends bucketed or boolean fields (e.g. freshness bucket, best-seller bucket) computed upstream rather than raw high-precision values or exact counts",
+        "Explains custom ranking as ordered tie-breaking after textual relevance, including why an overly precise first metric prevents later metrics from mattering",
+        "Routes any live rule or settings change to algolia-cli or algolia-mcp instead of writing it directly from this skill",
+        "Identifies the data-gap findings as work to complete before (or alongside) any dashboard rule"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "We index our store locations for a store finder (index: stores_us). Right now objectID is the store name slugified, and we shove the full weekly schedule, all 200+ inventory counts, and internal manager notes into each record. Search feels bloated and we keep having reindex problems whenever a store renames. Thoughts?",
+      "expected_output": "The response flags the objectID derived from a mutable display field (store name) as the root of the rename/reindex problem and recommends a stable identifier. It applies intentional record-size guidance: keep fields needed for retrieval, ranking, faceting, display, and event attribution; move or drop internal manager notes (also a data-exposure concern); replace exact volatile inventory counts with stable buckets or booleans to avoid constant reindexing. It includes a migration/reindex plan since changing objectIDs affects the index, and defers live record operations to algolia-cli or algolia-mcp.",
+      "files": [],
+      "expectations": [
+        "Identifies the slugified-store-name objectID as an unstable contract and recommends a stable ID not derived from mutable display fields",
+        "Recommends trimming record contents to fields needed for retrieval, ranking, faceting, display, and event attribution, and flags internal manager notes for removal or securing",
+        "Recommends buckets or booleans instead of exact volatile inventory counts to reduce unnecessary reindexing",
+        "Includes a migration/reindexing plan (or explicitly calls one out as required) because objectIDs are changing",
+        "Routes any live record mutations, imports, or exports to algolia-cli or algolia-mcp rather than performing them via this skill"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-data-modeling/references/data-modeling-guide.md
+++ b/skills/algolia-data-modeling/references/data-modeling-guide.md
@@ -1,0 +1,549 @@
+# Data Modeling Guide
+
+## Contents
+
+- [Index Contract](#index-contract)
+- [Record Shape Heuristics](#record-shape-heuristics)
+- [Ecommerce Record Model Decision](#ecommerce-record-model-decision)
+- [Common Ecommerce Data Gaps](#common-ecommerce-data-gaps)
+- [Merchandising Data Gap Readiness](#merchandising-data-gap-readiness)
+- [Academy Coaching Questions](#academy-coaching-questions)
+- [Minimum Data Sample Request](#minimum-data-sample-request)
+- [Low-Dev Data Path](#low-dev-data-path)
+- [ObjectID Decisions](#objectid-decisions)
+- [Variant Modeling Patterns](#variant-modeling-patterns)
+- [Variant Decision Prompt](#variant-decision-prompt)
+- [Custom Ranking Metric Map](#custom-ranking-metric-map)
+- [Concrete Record Templates](#concrete-record-templates)
+- [Index And Replica Patterns](#index-and-replica-patterns)
+- [Ingestion Guardrails](#ingestion-guardrails)
+- [Source Notes](#source-notes)
+
+## Index Contract
+
+Define this before writing ingestion code:
+
+- Index names for development, staging, production, and temporary rebuilds.
+- Record entity and granularity.
+- Stable `objectID` formula.
+- Searchable attributes.
+- Display attributes.
+- Faceting/filtering attributes.
+- Custom ranking attributes.
+- Secured or hidden attributes.
+- Replica and virtual replica strategy.
+- Event attribution fields required by the frontend.
+- Full reindex and incremental update ownership.
+
+## Record Shape Heuristics
+
+- Shape records around what a user expects to find and compare.
+- Denormalize fields needed for search, filtering, ranking, display, and event context.
+- Keep source-only relational details out of the record unless they affect search behavior.
+- Normalize facet values before indexing; inconsistent casing, pluralization, or synonyms create poor filters.
+- Include searchable synonyms or alternate names in records only when they represent content truth. Use synonyms/settings for query-language equivalence.
+- Store image URLs, not image binaries.
+- Compute ranking metrics during indexing when possible: popularity, margin band, availability score, freshness bucket, review score, conversion rate, or editorial priority.
+- Round overly precise custom ranking metrics so later tie-breakers can still matter.
+
+## Ecommerce Record Model Decision
+
+Use this when a catalog has base products and variants such as color, size, style, region, channel, or price list. The first decision is what one Algolia record should represent. That decision affects search relevance, facets, merchandising, AI behavior, analytics, events, update cost, and frontend complexity.
+
+| Model | One record represents | Best fit | Watchouts |
+| --- | --- | --- | --- |
+| Variant-level | One specific variation such as blue / size M / SKU | Precise variant matching, exact filters, variant pricing or stock, granular updates | More records, possible duplicate-looking results, requires grouping for product-family UI, AI and analytics may operate too narrowly unless parent IDs are preserved |
+| Variation-group-level | One product variation group such as a color with nested sizes | Product/color merchandising, variant-aware images, cleaner results than SKU-level, better AI and analytics grouping than pure SKU-level | The grouping attribute must be chosen deliberately; updates may require resending the group record |
+| Product-level / master product | One base product with all variants nested | One result per product, simpler merchandising, product-level AI/personalization/analytics, smaller record count | Facets and selected variant display can require frontend post-processing; partial variant updates are harder; filters can imply availability that only exists for one nested variant |
+
+Decision rules:
+
+- If users search or filter by variant attributes and expect exact matches, prefer variant-level or variation-group-level records.
+- If merchandisers work at the product family level and AI, personalization, or analytics should learn at product level, prefer product-level or variation-group-level records.
+- If color drives imagery and shopper intent, variation-group-level records often balance precision and manageability.
+- If price, stock, image, permissions, or conversion attribution differ by SKU, preserve variant IDs even when the UI groups results.
+- If product-level records contain nested variants, define how the frontend chooses the displayed image, price, URL, and availability after filters.
+
+Output requirement:
+
+- Name the chosen model, the grouping attribute if any, the parent ID, the event attribution IDs, and the expected UI behavior for search results, category pages, filters, and product detail handoff.
+
+## Common Ecommerce Data Gaps
+
+Use this section as an Academy-style diagnostic before recommending rules, boosts, replicas, or UI fixes. Many ecommerce ranking and merchandising failures are caused by missing fields rather than weak Algolia settings.
+
+### Record Model Gap
+
+Symptom:
+
+- The team cannot say whether a result is a product, color group, size, SKU, regional offer, or account-specific offer.
+
+Checks:
+
+- Does the sample data show one row per SKU, one row per product, or a mixture?
+- Can filters such as color plus size return only available matching variants?
+- Can the UI display the correct image, price, URL, and stock state for the matched variant?
+- Can events attribute clicks and conversions to the right product, variation group, or SKU?
+
+Fix:
+
+- Pick the record model first, then document the selected entity, parent ID, variant ID, grouping attribute, and analytics aggregation rule.
+
+### Attribute Gap
+
+Symptom:
+
+- Merchandisers want to boost, bury, filter, or analyze product groups that the index cannot identify.
+
+Checks:
+
+- Newness: is there `published_at`, `first_available_at`, `launched_at`, `is_new`, or `newness_bucket`?
+- Rating: is there a normalized customer rating or rating bucket?
+- Sales and popularity: are there sales, views, click, add-to-cart, purchase, conversion-rate, or velocity fields?
+- Margin: is margin exposed as a safe numeric value, band, or priority flag?
+- Sale and campaign: are sale status, discount bands, campaign IDs, season, and collection explicit?
+- Own brand: is brand ownership an explicit boolean or enum rather than inferred from a display name?
+
+Fix:
+
+- Add explicit merchandising attributes with allowed values and owners. Avoid inferring business concepts from product names, labels, or UI-only logic.
+
+### Business Metric Gap
+
+Symptom:
+
+- Custom ranking uses raw fields, but business stakeholders disagree about why products rank the way they do.
+
+Checks:
+
+- Which metric should matter first when text relevance ties: sales, margin, rating, popularity, freshness, inventory, or editorial priority?
+- Is the metric global, category-specific, query-specific, seasonal, or curated?
+- What is the time window: 7 days, 30 days, season-to-date, all-time, or launch period?
+- Should higher values rank first, or should lower values rank first?
+- Are values safe to expose, or should the index use buckets such as `margin_band`?
+
+Fix:
+
+- Create a custom ranking metric map with field, business meaning, direction, source owner, refresh cadence, precision, and validation query.
+
+### Precision And Tie-Breaking Gap
+
+Symptom:
+
+- The first custom ranking metric is so granular that later business metrics never affect ranking.
+
+Checks:
+
+- Do values such as rating, margin, sales, or popularity have many unique values?
+- Does the business expect margin to matter after sales, or freshness to matter after rating?
+- Would users perceive a difference between values such as 1,000 and 1,003 sales?
+
+Fix:
+
+- Reduce precision or bucket continuous metrics before indexing. Examples: `rating_rounded`, `sales_30d_bucket`, `margin_band`, `freshness_bucket`, `popularity_decile`, or `inventory_bucket`.
+- Order custom ranking attributes from most important to least important business tie-breaker.
+- Validate with representative queries where several records have similar textual relevance.
+
+## Merchandising Data Gap Readiness
+
+Before launching merchandising, check whether the data can support the business strategy. Most merchandising problems are not rule problems first; they are missing schema, timestamp, attribute, inventory, or sales-signal problems.
+
+Use this as a coaching moment with business users: first define the merchandising strategy in business language, then confirm the index contains the attributes required to execute that strategy.
+
+### Product Or Variant Schema
+
+Choose whether merchandising happens at the product, variant, SKU, region, account, or grouped-variant level before indexing.
+
+Check:
+
+- What should one promoted hit represent: a product family, a color, a size, a SKU, a bundle, or a location-specific offer?
+- Can a variant override the parent product's image, price, availability, sale status, or promotion status?
+- If variants are indexed separately, is there a parent ID such as `product_id` for grouping and analytics?
+- If products are indexed as one record, are variant values such as colors, sizes, price bands, and availability represented without misleading filters?
+
+Common gap:
+
+- Product and variant fields are mixed without a clear display rule, so a low-priority variant can override the main product, or filters imply availability that only exists for one variant.
+
+Output requirement:
+
+- State the selected product/variant strategy and the tradeoff for search pages, category pages, filters, merchandising, and events.
+
+### New Products And Timestamps
+
+Define "new" before indexing. Algolia can rank or filter by fields, but the business must decide what qualifies as new for each category.
+
+Check:
+
+- Is there a reliable source timestamp such as `published_at`, `first_available_at`, or `launched_at`?
+- Are timestamps normalized to a consistent timezone and format before indexing?
+- Does "new" mean the same thing across categories, or does apparel, electronics, content, and seasonal inventory each need a different window?
+- Is there a precomputed field such as `is_new`, `newness_bucket`, or `days_since_launch_bucket` when business users need simple merchandising controls?
+
+Common gap:
+
+- Missing or incorrect dates cause old products to be promoted as new, or new products are not distinguishable because no attribute marks them as new.
+
+Output requirement:
+
+- Define the timestamp source, the business meaning of newness, the field that Algolia receives, and the owner who keeps it current.
+
+### Promotion Attributes
+
+Merchandising rules need explicit attributes. Do not rely on labels, names, or UI-only logic to infer promotion groups.
+
+Check:
+
+- Sale: `is_on_sale`, `sale_bucket`, `discount_percentage_bucket`, or campaign IDs.
+- Own brand: `is_own_brand` or a normalized brand ownership flag, not only a brand name string.
+- Category campaigns: `campaign_ids`, `season`, `collection`, `merchandising_priority`, or editorial flags.
+- Exclusions: `is_clearance`, `is_restricted`, `is_discontinued`, or `is_hidden`.
+
+Common gap:
+
+- Products that should be promoted are not tagged, or products are misclassified because the source data has inconsistent brand, sale, or campaign fields.
+
+Output requirement:
+
+- List each merchandising group, the exact attribute that powers it, the allowed values, and the source owner.
+
+### Inventory And Stock Buckets
+
+Do not default to exact stock counts in Algolia. Exact counts can create noisy updates because every sale may require a reindex. Prefer business-useful buckets or booleans unless exact counts are truly needed.
+
+Check:
+
+- Is the product in stock, out of stock, preorder, backorder, low stock, or high inventory?
+- What does "high inventory" mean for this category or business: units, days of supply, overstock status, location availability, or a manually maintained bucket?
+- Should out-of-stock items be hidden, buried, shown with messaging, or excluded from promotions?
+- How often does the inventory bucket need to refresh without overloading indexing?
+
+Recommended fields:
+
+- `in_stock`: boolean for basic availability.
+- `stock_bucket`: values such as `out_of_stock`, `low`, `normal`, `high`.
+- `high_inventory`: boolean only if the business has a clear definition.
+- `availability_scope`: optional region/store/channel value when availability differs by context.
+
+Common gap:
+
+- Out-of-stock products get promoted because inventory is stale, missing, or too granular to maintain reliably.
+
+Output requirement:
+
+- Define the inventory bucket logic, refresh cadence, and what merchandising should do with each bucket.
+
+### Best Sellers And Sales Signals
+
+Define best sellers upstream. Algolia can use a ranking or filtering field, but the source data needs to decide what counts.
+
+Check:
+
+- Does "best selling" mean units sold, revenue, conversion rate, velocity, category rank, or a merchandising-selected group?
+- Is the window fixed: 7 days, 30 days, season-to-date, category-specific, or all-time?
+- Are values bucketed enough to avoid overfitting and noisy ranking changes?
+- Are category-level best sellers computed within category, not globally, when category pages need local relevance?
+
+Recommended fields:
+
+- `best_seller_bucket`: values such as `none`, `category_top`, `site_top`, `seasonal_top`.
+- `sales_velocity_bucket`: values such as `low`, `medium`, `high`.
+- `category_sales_rank`: numeric rank only when maintained and meaningful.
+
+Common gap:
+
+- Missing or stale sales data promotes the wrong products, or a global best seller dominates unrelated categories.
+
+Output requirement:
+
+- Define the sales metric, time window, category scope, bucket values, and refresh owner.
+
+### Margin, Rating, And Popularity Signals
+
+Sales alone rarely captures the whole merchandising strategy. Decide how other metrics participate before indexing.
+
+Check:
+
+- Is margin used as a direct metric, a band, or a private editorial priority?
+- Is customer rating trustworthy enough, and does it need a minimum review count or Bayesian average before ranking?
+- Does popularity mean views, clicks, add-to-cart, purchases, conversion rate, or a blended score?
+- Should these metrics be global or category-specific?
+- Are values rounded or bucketed enough that downstream tie-breakers still matter?
+
+Recommended fields:
+
+- `margin_band`: numeric or enum such as `low`, `medium`, `high`.
+- `rating_rounded`: normalized rating rounded to a useful precision.
+- `review_count_bucket`: avoids overvaluing a perfect rating with too few reviews.
+- `popularity_bucket` or `sales_velocity_bucket`: stable enough for ranking and merchandising.
+- `editorial_priority`: curated business override when appropriate.
+
+Common gap:
+
+- A product with a tiny advantage in a raw metric always wins even though business users expected the next metric to break ties.
+
+Output requirement:
+
+- Define the metric order, precision, owner, refresh cadence, and validation query for each ranking input.
+
+### Monitoring And Continuous Improvement
+
+Data quality is not one-and-done. Build a review loop between data, engineering, merchandising, and customer-facing owners.
+
+Track:
+
+- Missing required merchandising attributes.
+- Records with impossible or stale dates.
+- Products with unclear product/variant ownership.
+- Out-of-stock products appearing in promoted groups.
+- Products marked as new or best seller outside the agreed definition.
+- Record count, failed indexing jobs, last feed update, and major bucket distribution changes.
+
+Output requirement:
+
+- Include a data-gap report with owner, severity, affected merchandising strategy, and validation query or dashboard check.
+
+### Impact Review
+
+After gaps are fixed, review whether merchandising quality improved.
+
+Measure:
+
+- Product visibility for targeted groups.
+- Click-through rate, conversion, add-to-cart, revenue, or support deflection where relevant.
+- No-result and no-click queries.
+- Promotion accuracy: promoted products match the intended category, stock, freshness, sale, brand, or best-seller definition.
+
+Output requirement:
+
+- Compare before/after examples and state which data fixes likely drove the change.
+
+## Academy Coaching Questions
+
+Use these questions to help nontechnical customers find data gaps before engineering starts:
+
+- Product or variant: "When you promote this item, do you mean the whole product family, one color, one size, one SKU, or one regional offer?"
+- Newness: "What exactly counts as new for this category, and which upstream field proves it?"
+- Sale and own brand: "Which explicit attributes identify sale items and owned-brand items without relying on display names?"
+- Inventory: "Do merchandisers need exact stock counts, or do they need useful buckets such as out of stock, low, normal, and high?"
+- Best sellers: "Is best-selling based on units, revenue, velocity, conversion, category rank, or a curated list, and over what time window?"
+- Ownership: "Who owns each flag or bucket, and how often does it refresh?"
+
+If the answer is unclear, mark the implementation as provisional and produce a data-gap report before recommending indexing or merchandising rules.
+
+## Minimum Data Sample Request
+
+Before designing the final contract, ask for the smallest sample that exposes real complexity:
+
+- 5 normal records users should find easily.
+- 5 edge-case records: variants, unavailable items, restricted items, regional or account-specific items, localized content, stale content, or items with missing fields.
+- Current field names from the source system.
+- Fields shown in the UI today.
+- Filters, sorts, and ranking signals the business expects.
+- One or two examples of searches that should return each record.
+
+If the customer cannot provide source records, create a provisional contract with clear placeholders and mark every assumption that must be validated before launch.
+
+## Low-Dev Data Path
+
+For teams without a full development team, separate data work into what can be prepared now and what needs implementation access:
+
+- Customer can usually define searchable fields, display fields, filters, ranking intent, record examples, and owner decisions.
+- Customer may be able to provide CSV exports, product feeds, CMS exports, screenshots, or API samples.
+- Developer or platform owner is usually needed for automated indexing, stable objectID generation, incremental updates, secured filters, and production deployment.
+- Do not let a temporary CSV shape become the long-term contract unless it includes stable IDs, variant strategy, and update ownership.
+
+## ObjectID Decisions
+
+Use a stable objectID that survives display-name, URL, and categorization changes. Prefer source IDs or deterministic composite IDs such as `productId::variantId::locale` when those dimensions produce distinct records.
+
+Ask before choosing composite IDs:
+
+- Does each variant need its own result, or should variants be grouped?
+- Do locales or regions have materially different searchable text, availability, price, permissions, or events?
+- Will events and analytics need to aggregate variants into products?
+
+## Variant Modeling Patterns
+
+Choose the variant shape before indexing. This decision affects relevance, filters, event attribution, analytics, and UI behavior.
+
+### Product-As-Record
+
+Use one record for the product family when:
+
+- Users expect one result per product.
+- Variants share most searchable text, categories, images, and ranking signals.
+- Variant choice happens on the product detail page.
+- Facets can safely represent aggregated variant values such as available colors or sizes.
+
+Watchouts:
+
+- Availability, price, and promotion data can become ambiguous.
+- A filter such as `size:M` may show a product even if only one color has that size.
+- Events may need product-level and selected-variant context.
+
+### Variant-As-Record
+
+Use one record per variant or SKU when:
+
+- Users compare, filter, price, or convert at the variant level.
+- Variants have distinct titles, images, prices, availability, stores, channels, or permissions.
+- Merchandising needs to promote or bury specific variants.
+- Events and analytics need variant-level attribution.
+
+Watchouts:
+
+- Results can look duplicated unless the UI groups or de-duplicates families.
+- The index may grow quickly.
+- Aggregated product analytics need a parent ID such as `product_id`.
+
+### Grouped Variant Records
+
+Use variant records plus grouping/distinct behavior when:
+
+- Ranking and filtering need variant precision.
+- The UI should usually show one product family.
+- The selected variant should reflect the query or filters.
+
+Include:
+
+- Stable `objectID` per variant.
+- Parent identifier such as `product_id`.
+- Variant attributes such as color, size, material, region, channel, price, availability, image, and URL.
+- Display fields for both parent product and selected variant.
+
+### Variation-Group-Level Records
+
+Use one record per shared variation, commonly color, when:
+
+- Users often search by that variation.
+- Images and merchandising should align to the variation.
+- Product-level records are too broad for filters, but SKU-level records create too many duplicate-looking results.
+- AI, analytics, and merchandising should operate above the individual SKU level.
+
+Include:
+
+- Stable `objectID` per variation group.
+- Parent identifier such as `product_id`.
+- Grouping attribute such as `color`.
+- Nested variants for size, SKU, price, stock, or URL.
+- Parent-level searchable text and group-level display fields.
+
+Watchouts:
+
+- Choose the grouping attribute carefully; color is common, but not universal.
+- If the group contains nested SKUs, define how updates occur when one SKU changes price or availability.
+- Events may need both group-level and SKU-level identifiers when conversion happens after size selection.
+
+### Locale, Region, Channel, Account, And Permission Variants
+
+Create separate records or indices when a dimension materially changes:
+
+- Searchable text or language.
+- Availability, currency, price list, or tax display.
+- Compliance, permissions, or secured filters.
+- Ranking signals or event streams.
+- Operational ownership or deployment cadence.
+
+Use filters when the same record can safely serve multiple contexts. Use separate records or indices when a single record would create confusing facets, unsafe access, or misleading analytics.
+
+## Variant Decision Prompt
+
+Ask:
+
+1. What should one search result represent?
+2. Which variant attributes can users search, filter, sort, compare, or buy?
+3. Do price, availability, permissions, or images differ by variant?
+4. Do events need product-level, variant-level, or both identifiers?
+5. Should the UI show one family result or many variant results?
+6. Which dimensions require separate records, filters, or indices?
+7. If grouping variants, which shared attribute is the group key and why?
+8. Should AI, personalization, analytics, and merchandising learn at product, variation group, or SKU level?
+
+## Custom Ranking Metric Map
+
+Before setting custom ranking, produce a metric map. Custom ranking should reflect business tie-breakers after textual relevance, not every available business number.
+
+| Field | Meaning | Direction | Scope | Precision | Owner | Refresh | Validation |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `sales_30d_bucket` | Recent sales velocity | Desc | Category-specific | Bucketed | Analytics / data pipeline | Daily | Similar products with higher recent velocity rank ahead |
+| `margin_band` | Profitability group | Desc | Global or category | Bucketed | Merchandising / finance | Weekly or feed update | Higher-margin products break ties after sales |
+| `freshness_bucket` | Newness window | Desc | Category-specific | Bucketed | Catalog / merchandising | Feed update | New products get visibility without overwhelming relevance |
+| `rating_rounded` | Customer satisfaction | Desc | Global | Rounded | Reviews platform | Daily | Ratings affect ties only after enough review volume |
+
+Design rules:
+
+- Use numeric or boolean values for custom ranking fields.
+- Decide the order deliberately; the first custom ranking field has the most influence when records tie on textual relevance.
+- Reduce precision when two values are not meaningfully different to users or business stakeholders.
+- Prefer category-specific metrics when category pages should not be dominated by global best sellers.
+- Keep private or sensitive business values as bands, buckets, or priority fields instead of exposing exact values.
+- Validate ranking with query sets that include likely ties, not only obvious winners.
+
+## Concrete Record Templates
+
+Use these as contract starters, not fixed schemas.
+
+### Ecommerce Variant Record
+
+Required decisions:
+
+- `objectID`: `productId::variantId::locale` or equivalent stable composite.
+- Parent ID: `product_id` for grouping and analytics aggregation.
+- Variant fields: `variant_id`, `sku`, `color`, `size`, `material`, `image_url`, `variant_url`.
+- Search fields: product title, brand, category, variant descriptors, searchable attributes.
+- Filter fields: availability, price band, color, size, category, brand, locale, channel.
+- Ranking fields: popularity, conversion rate, margin band, inventory score, freshness.
+- Event fields: product ID and variant ID must both be available to the UI when conversion attribution needs both.
+
+### B2B Account Pricing Record
+
+Required decisions:
+
+- Whether account-specific price and availability require separate records, secured filters, or separate indices.
+- `account_id`, `price_list_id`, `contract_available`, and region/channel filters if exposed.
+- Secured filters for account, role, region, or contract eligibility.
+- ObjectID composite only when the same item has materially different searchable or purchasable state per account.
+
+### Locale Or Region Record
+
+Required decisions:
+
+- Whether localized text, currency, compliance, inventory, or ranking differs enough to require separate records.
+- ObjectID pattern such as `sourceId::locale::region` when distinct records are needed.
+- Normalized locale and region filters.
+- Localized searchable attributes and display fields.
+- Event aggregation strategy across locales.
+
+### Support Knowledge Base Article Record
+
+Required decisions:
+
+- One record per article, section, paragraph, or answer chunk.
+- Stable source ID plus locale or version when content differs.
+- Search fields: title, summary, body excerpt, product area, symptoms, error codes, audience.
+- Filter fields: product, version, role, visibility, locale, content type.
+- Ranking fields: freshness, helpfulness, support deflection, editorial priority.
+- Events: article click, helpful/not helpful, case deflection, escalation, or completion.
+
+## Index And Replica Patterns
+
+- One primary index per searchable entity and environment is the default.
+- Use replicas for explicit sort-by options such as price ascending, newest, or rating.
+- Use virtual replicas for relevant sorting when the goal is to bias while retaining stronger textual relevance.
+- Use separate indices when records, settings, access controls, languages, or operational ownership differ enough that one index becomes confusing.
+- Avoid separate indices only because a frontend route is different; filters or rules may be enough for category/browse pages.
+
+## Ingestion Guardrails
+
+- Create settings as code where possible, not only by dashboard clicks.
+- Use temporary indices for rebuilds and move/swap once complete when downtime or partial data would be harmful.
+- Never run destructive production indexing from a local experiment without explicit confirmation.
+- Track record counts, failed records, last updated timestamp, and index task completion.
+- Include a sample record fixture in tests for every important entity type.
+
+## Source Notes
+
+- Algolia recommends records include only what helps search, display, sorting, and relevance, and that records can be denormalized rather than relational: https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data
+- Searchable attributes should be deliberately selected because all attributes are searchable by default unless configured: https://www.algolia.com/doc/guides/managing-results/must-do/searchable-attributes
+- Custom ranking attributes must be numeric or boolean and are used to break ranking ties after textual criteria: https://www.algolia.com/doc/guides/managing-results/must-do/custom-ranking

--- a/skills/algolia-data-modeling/references/example-output.md
+++ b/skills/algolia-data-modeling/references/example-output.md
@@ -1,0 +1,109 @@
+# Example Output: Ecommerce Variant Index Contract
+
+Use this as a shape, not a fixed schema.
+
+## Customer Goal
+
+Help shoppers find the right shoe by brand, product name, color, size, gender, activity, price, and availability. Shoppers should usually see one product family, but filters must respect variant-level color, size, and availability.
+
+## Recommended Variant Strategy
+
+Use variant records with product grouping.
+
+- One record per sellable variant because color, size, image, price, URL, and availability can differ.
+- Include `product_id` so the UI can group variants into one product family when appropriate.
+- Use `objectID = product_id::variant_id::locale`.
+- Preserve both product-level and variant-level IDs for analytics and conversion attribution.
+
+Tradeoff:
+
+- Variant-level records make color, size, price, and availability filters accurate without frontend post-processing.
+- The UI must group or de-duplicate variants when shoppers should see one product family.
+- AI, personalization, analytics, and merchandising should preserve parent IDs so behavior can be reviewed above the SKU level.
+
+## Sample Record
+
+```json
+{
+  "objectID": "shoe-123::blue-9::en-US",
+  "product_id": "shoe-123",
+  "variant_id": "blue-9",
+  "sku": "SHOE-123-BLU-9",
+  "locale": "en-US",
+  "title": "Trail Runner 2",
+  "brand": "North Peak",
+  "description": "Lightweight waterproof trail running shoe.",
+  "category": ["Shoes", "Running", "Trail Running"],
+  "gender": "Women",
+  "activity": ["Running", "Hiking"],
+  "color": "Blue",
+  "size": "9",
+  "price": 129.99,
+  "price_band": "100-150",
+  "in_stock": true,
+  "stock_bucket": "high",
+  "is_new": true,
+  "first_available_at": 1751328000,
+  "is_on_sale": false,
+  "is_own_brand": true,
+  "best_seller_bucket": "category_top",
+  "sales_velocity_bucket": "high",
+  "sales_30d_bucket": 4,
+  "margin_band": 3,
+  "rating_rounded": 4.6,
+  "review_count_bucket": "100-499",
+  "freshness_bucket": "new_30d",
+  "image_url": "https://example.com/images/shoe-123-blue.jpg",
+  "url": "https://example.com/products/trail-runner-2?color=blue&size=9"
+}
+```
+
+## Merchandising Data Readiness
+
+| Strategy | Field | Decision |
+| --- | --- | --- |
+| Product/variant merchandising | `product_id`, `variant_id`, `stock_bucket`, selected variant image/URL | Variants are indexed separately, then grouped in UI where appropriate. |
+| New products | `first_available_at`, `is_new` | New means first available in the category within the agreed business window. Calculated before indexing. |
+| On sale | `is_on_sale` | Source system owns the sale flag; Algolia rules should not infer sale status from copy or price text. |
+| Own brand | `is_own_brand` | Boolean flag avoids brittle brand-name matching. |
+| High inventory | `stock_bucket` | Use `low`, `normal`, `high`, `out_of_stock`; avoid exact stock counts unless required. |
+| Best sellers | `best_seller_bucket`, `sales_velocity_bucket` | Bucketed upstream using category-specific sales window. |
+| Margin | `margin_band` | Bucketed so private margin values are not exposed and tie-breaking stays interpretable. |
+| Rating | `rating_rounded`, `review_count_bucket` | Rating is rounded; review volume prevents overvaluing thin review data. |
+
+## Custom Ranking Metric Map
+
+| Order | Field | Direction | Business meaning | Precision decision | Owner |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `in_stock` | Desc | Available products should win ties over unavailable products. | Boolean | Inventory feed owner |
+| 2 | `sales_30d_bucket` | Desc | Recent category sales velocity. | Bucketed 1-5 so margin can still break close ties. | Analytics pipeline |
+| 3 | `margin_band` | Desc | Prefer higher-margin products when relevance and velocity are similar. | Bucketed, not exact margin. | Merchandising / finance |
+| 4 | `freshness_bucket` | Desc | Give new products a controlled visibility lift. | Bucketed by category window. | Catalog owner |
+| 5 | `rating_rounded` | Desc | Prefer better-rated products after stronger business metrics. | Rounded to one decimal. | Reviews platform |
+
+## Initial Index Settings To Validate
+
+- Searchable attributes: `title`, `brand`, `category`, `activity`, `description`, `sku`.
+- Facets: `brand`, `category`, `gender`, `activity`, `color`, `size`, `price_band`, `in_stock`, `stock_bucket`, `is_on_sale`, `is_own_brand`.
+- Custom ranking candidates: `desc(in_stock)`, `desc(sales_30d_bucket)`, `desc(margin_band)`, `desc(freshness_bucket)`, and `desc(rating_rounded)`. Validate exact order with representative queries and business owners.
+- Replica candidates: price ascending, price descending, newest, rating if those experiences exist.
+
+## Validation Queries
+
+| Query or browse path | Expected behavior |
+| --- | --- |
+| `blue trail running shoes` | Blue trail shoes rank above generic running shoes. |
+| `north peak runner` | North Peak products rank ahead of unrelated brands. |
+| Filter `size:9` and `color:Blue` | Only products with an available blue size 9 variant appear. |
+| Category `Trail Running` | Category results respect availability and ranking signals. |
+
+## Customer Questions Still Needed
+
+- Should unavailable variants disappear, sort lower, or remain visible with messaging?
+- Should sale price, margin, rating, or inventory be stronger tie-breakers?
+- What counts as "new", "high inventory", and "best seller" for this category?
+- Should sales, margin, freshness, or rating be the stronger tie-breaker when products are textually similar?
+- Are current sales, margin, and rating values too precise, and which should be bucketed before indexing?
+- Who owns the upstream flags and buckets that power merchandising?
+- Should analytics aggregate by product, variant, or both?
+- Do region, currency, account, or permission rules change availability?

--- a/skills/algolia-discovery-planning/SKILL.md
+++ b/skills/algolia-discovery-planning/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: algolia-discovery-planning
+description: >
+  START HERE for any non-trivial Algolia work — building, adding, migrating, redesigning, auditing, or configuring search, browse, autocomplete, indexing, relevance, recommendations, personalization, merchandising, events, or analytics. Invoke this FIRST even when the task already seems scoped or the user names one specific feature (e.g. "add InstantSearch", "build a storefront search"): its job is to map the request to the full Algolia implementation lifecycle and load every companion skill each in-scope phase needs (algolia-search-implementation, algolia-data-modeling, algolia-index-configuration, algolia-ui-libraries, algolia-instantsearch-ui, algolia-autocomplete, algolia-events-insights, algolia-neuralsearch, algolia-agent-studio, algolia-release-qa) rather than jumping straight into a single skill. This skill plans and orchestrates; the focused companion skills and the official Algolia skills execute. Do NOT use for live account inspection or write actions; use algolia-mcp or algolia-cli for those.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.4"
+---
+
+# Algolia Discovery Planning
+
+Use this skill before implementation work when the business goal, data shape, UX, event strategy, or success criteria are unclear. The job is to slow down just enough to avoid encoding the wrong search strategy.
+
+## Orchestrate The Whole Library (do this first)
+
+These skills are a **suite that spans the Algolia implementation lifecycle**, not a set of independent tools where one match wins. A request that looks like a single-skill task ("build search", "add autocomplete", "index my data") almost always spans several phases. Before writing code or changing settings:
+
+1. **Map the request to the lifecycle** and mark every phase that is in scope:
+
+   | Phase | Load this skill | Typical trigger |
+   | --- | --- | --- |
+   | Run a net-new build end to end | `algolia-search-implementation` | greenfield search/browse/ecommerce build; keeps checkpoints, signposts, and deferrals explicit |
+   | Shape the data / records | `algolia-data-modeling` | new index, catalog, variants, objectID, ETL |
+   | Configure relevance | `algolia-index-configuration` | searchable attrs, ranking, facets, synonyms, rules, replicas, sort |
+   | Choose the UI library | `algolia-ui-libraries` | framework fit, InstantSearch vs Autocomplete, SSR/routing, mobile SDKs, upgrades |
+   | Build the results/browse UI | `algolia-instantsearch-ui` | search results page, filters, category/browse |
+   | Build typeahead | `algolia-autocomplete` | query suggestions, autocomplete panel |
+   | Instrument behavior | `algolia-events-insights` | click/view/add-to-cart/conversion, personalization, Recommend, A/B |
+   | Pre-launch check | `algolia-release-qa` | before shipping or after a risky change |
+   | AI / conversational | `algolia-agent-studio`, `algolia-neuralsearch` | agents, RAG, semantic/neural retrieval |
+
+2. **State the phase plan** to the user: which phases apply, which skill owns each, and the order (a greenfield build usually runs data-modeling → index-configuration → instantsearch-ui / autocomplete → events-insights → release-qa).
+
+3. **Load each in-scope skill via the Skill tool for its phase, and actually apply its guidance.** Do not skip a phase silently, and do not substitute your own knowledge for a skill that applies. If you deliberately skip a phase, say so and why.
+
+4. **Never claim a skill informed the work unless it was opened.** Report which skills ran and what each changed.
+
+This is the default behavior for any multi-phase task. Only collapse to a single focused skill for a genuinely narrow, single-phase ask (e.g. "rename one facet label").
+
+## Customer-Facing Standard
+
+- Ask only the questions needed to choose a responsible next step.
+- State assumptions plainly when proceeding with incomplete context.
+- Use public `academy.algolia.com` for learning alignment and public `algolia.com/doc` for current implementation guidance when source-backed context is needed.
+- When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
+- Do not require custom Academy/docs access; use customer-provided sources only as optional context.
+- When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
+- Produce a concrete next step, owner handoff, and validation artifact.
+
+## Official Companion Skills
+
+- Use official `algolia-mcp` when discovery needs live search, analytics, recommendations, or index discovery.
+- Use official `algolia-cli` when discovery identifies records, settings, rules, synonyms, keys, backups, or index operations.
+- Use official `algobot-cli` for Agent Studio, RAG, conversational AI, and agent configuration paths.
+- Use official `instantsearch` for production InstantSearch or Autocomplete implementation paths.
+
+## Source-Of-Truth Rules
+
+- Do not answer account-specific questions from memory. Use MCP, CLI, dashboard exports, customer-provided screenshots, or sample files when live evidence is needed.
+- Do not recommend a product capability, package, command, or API shape without checking the official skill or current public docs when it affects implementation.
+- If evidence is unavailable, label the recommendation as provisional and name the exact artifact needed to confirm it.
+
+## Workflow
+
+1. Identify the implementation surface: indexing, relevance configuration, Search UI, Autocomplete, events, analytics, recommendations, personalization, merchandising, migration, or QA.
+2. Ask only the questions that block a responsible first design. Do not ask every checklist item at once.
+3. If the user wants you to proceed without answers, state the assumptions and choose reversible defaults.
+4. If the customer does not have a dedicated development or Algolia team, produce a practical handoff plan before implementation: what can be decided now, what access is needed, what likely requires developer help, and the safest first milestone.
+5. Load **every** in-scope companion skill (usually several, per the lifecycle map above), in phase order, and apply each — do not stop at the first match:
+   - `$algolia-search-implementation` for net-new builds, as the checkpoint checklist that spans the phases below.
+   - `$algolia-data-modeling` for records, indices, replicas, ETL, and record identity.
+   - `$algolia-index-configuration` for relevance, ranking, facets, synonyms, rules, and replicas.
+   - `$algolia-events-insights` for click, conversion, view, and Add-to-Cart events.
+   - `$algolia-ui-libraries` for choosing the current UI library and docs path before UI implementation.
+   - `$algolia-instantsearch-ui` for search results pages and browse/category experiences.
+   - `$algolia-autocomplete` for query suggestions and typeahead experiences.
+   - `$algolia-release-qa` for launch checks, diagnostics, and regressions.
+
+## Context Questions
+
+Read `references/discovery-question-bank.md` when the task is ambiguous or customer-facing. Select 3-7 questions from the relevant section, then proceed with explicit assumptions.
+
+Prefer questions that uncover:
+
+- Business outcomes: revenue, conversion, deflection, content discovery, operational efficiency.
+- Users and journeys: searchers, merchandisers, developers, support agents, admins.
+- Content and data: product, article, location, user-generated, B2B catalog, secured content.
+- Ranking intent: exact match, popularity, margin, availability, freshness, geo, personalization, business priority.
+- UX shape: search page, category browse, federated search, autocomplete, filters, sort-by, recommendations.
+- Measurement: events available, conversion definitions, analytics ownership, A/B testing appetite.
+- Governance: environments, index naming, access controls, rollout plan, rollback plan.
+
+## Academy And Customer Education Alignment
+
+When source-backed guidance is needed, search public Academy sources for relevant learning objectives and public Algolia docs for implementation details. Classify the request by maturity level: beginner implementation, production readiness, optimization, or AI readiness. Also classify the use case: ecommerce search, content search, B2B catalog, support knowledge base, marketplace, or AI shopping assistant.
+
+## Start Prompt
+
+When the user is unsure where to begin, offer this prompt:
+
+```text
+Use the Algolia Discovery Planning skill to help me choose the right implementation path. Ask me only the questions needed to understand my goal, data, search UI, events, and launch risk. Assume I may not know which technical details matter yet. Then recommend the next Algolia skill, the smallest useful first milestone, and the validation artifact I should create.
+```
+
+## Maturity Behavior
+
+- Beginner implementation: identify the simplest correct first milestone and the minimum source material needed.
+- Production readiness: identify launch blockers, owners, rollback needs, and validation artifacts.
+- Optimization: identify baseline metrics, representative query sets, and controlled improvement paths.
+- AI readiness: identify whether data, events, permissions, and relevance evaluation are strong enough for NeuralSearch, Agent Studio, or AI assistants.
+
+## Output Contract
+
+When discovery is needed, produce:
+
+- Known facts.
+- Open questions that materially change the design.
+- Assumptions you will use if the user wants you to continue.
+- Recommended next skill or implementation step.
+- Customer handoff notes when the team needs help from a platform owner, developer, analytics owner, or implementation vendor.
+- Evidence needed before implementation, such as sample records, settings export, analytics screenshots, event payloads, or code access.
+
+Keep the response short enough that the user can answer. The point is momentum with fewer hidden traps.

--- a/skills/algolia-discovery-planning/agents/openai.yaml
+++ b/skills/algolia-discovery-planning/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia Discovery Planning"
+  short_description: "Ask the right Algolia setup questions"
+  default_prompt: "Use $algolia-discovery-planning to clarify business context before designing my Algolia implementation."

--- a/skills/algolia-discovery-planning/evals/evals.json
+++ b/skills/algolia-discovery-planning/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "algolia-discovery-planning",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "hey - we're a mid-size outdoor gear retailer and we just signed with Algolia. I've been told to \"add InstantSearch to the site\". We're on Next.js 14, catalog is in a Postgres db (~25k products, most have size/color variants), nothing is indexed yet, no events, nothing. Can you just help me drop the InstantSearch widgets in?",
+      "expected_output": "The response does not jump straight into InstantSearch widget code. It maps the request to the full implementation lifecycle, states a phase plan (data modeling, index configuration, UI library choice, InstantSearch UI, autocomplete if in scope, events, release QA) with which companion skill owns each phase and in what order, flags that nothing is indexed yet so data-modeling comes before UI, and asks only the few questions that block a responsible first design (e.g. variant expectations, business goal, conversion definition). It ends with a concrete recommended next step and the evidence needed (sample records, etc.).",
+      "files": [],
+      "expectations": [
+        "Does not treat the task as UI-only; explicitly maps the request to multiple lifecycle phases rather than stopping at InstantSearch",
+        "States a phase plan naming sibling skills for each phase (e.g. algolia-data-modeling, algolia-index-configuration, algolia-ui-libraries or algolia-instantsearch-ui, algolia-events-insights, algolia-release-qa) and the order they should run",
+        "Identifies that records must be modeled and indexed before UI work, since the catalog is in Postgres and nothing is indexed yet",
+        "Asks a small number of targeted discovery questions (roughly 3-7) about goals, variants, UX shape, or events instead of dumping an exhaustive checklist",
+        "Produces an output that includes known facts, open questions, assumptions, and a recommended next skill or step",
+        "Does not claim any companion skill informed the work unless it was actually loaded"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Our support team wants to reduce ticket volume with better search on our help center (Zendesk articles, ~1200 docs). Leadership keeps saying 'AI search'. I honestly don't know if we need NeuralSearch, an Agent Studio chatbot, or just decent keyword search with synonyms. Where do we even start?",
+      "expected_output": "The response runs discovery instead of picking a product. It asks targeted questions about business outcome (deflection metric), users, content shape, and measurement; classifies the maturity level (likely beginner implementation vs AI readiness); explains that AI features like NeuralSearch and Agent Studio depend on data and event readiness; and recommends a concrete first milestone with the right companion skills for each in-scope phase. It states assumptions plainly if proceeding without answers and names the validation artifact to produce.",
+      "files": [],
+      "expectations": [
+        "Asks about or establishes the business outcome (ticket deflection / conversion definition) before recommending NeuralSearch, Agent Studio, or plain keyword search",
+        "Classifies the request by maturity level (e.g. beginner implementation vs AI readiness) and lets that drive the recommendation",
+        "States that AI features depend on data quality and event/measurement readiness rather than treating them as a starting point",
+        "Recommends a smallest useful first milestone plus the next skill(s) to load, rather than a vague multi-option essay",
+        "Output includes open questions, explicit assumptions, and the evidence or artifacts needed before implementation (e.g. sample articles, analytics)",
+        "Does not answer account-specific questions from memory; if live data is referenced, routes inspection to algolia-mcp or algolia-cli"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "quick one: can you check what our current searchableAttributes are on the prod_products index and then plan out how we should restructure relevance? App ID is BX9KF2M1QP, I can give you an API key.",
+      "expected_output": "The response routes the live inspection of prod_products settings to the official algolia-mcp or algolia-cli rather than performing or fabricating it via this planning skill, and does not invent current settings from memory. It then frames the relevance restructuring as a planning task: capture current settings as evidence first, then load algolia-index-configuration for the relevance design phase, with a stated plan and validation artifacts.",
+      "files": [],
+      "expectations": [
+        "Routes the live settings inspection to algolia-mcp or algolia-cli instead of claiming this skill can read the index",
+        "Does not fabricate or guess the current searchableAttributes of prod_products",
+        "Names algolia-index-configuration as the skill that owns the relevance redesign phase after evidence is captured",
+        "Recommends capturing current settings (settings export or live tool output) as evidence before proposing changes",
+        "Produces a concrete next step and identifies the validation artifact (e.g. settings backup, representative query set)"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-discovery-planning/references/discovery-question-bank.md
+++ b/skills/algolia-discovery-planning/references/discovery-question-bank.md
@@ -1,0 +1,68 @@
+# Discovery Question Bank
+
+Use this bank selectively. Ask the minimum number of questions needed to avoid designing the wrong Algolia implementation.
+
+## First-Turn Triage
+
+- What user journey are we improving: search, browse/category, autocomplete, recommendations, internal lookup, support/content discovery, or merchandising?
+- What outcome matters most: conversion, revenue, add-to-cart, lead generation, content consumption, support deflection, speed, or admin efficiency?
+- What is the primary content type: products, SKUs, variants, articles, locations, people, accounts, tickets, docs, or mixed/federated content?
+- Is this a new implementation, migration, redesign, relevance tuning project, analytics/event setup, or launch audit?
+- Which environment can we safely change: local, development, staging, production, or a temporary test index?
+
+## Business Context
+
+- What does a "good result" mean for this business and user? Exact textual match, availability, freshness, popularity, margin, geo proximity, personalization, diversity, or editorial control?
+- Which searches or categories are most valuable?
+- Which failures are most costly: no results, wrong top result, irrelevant recall, missing filters, stale data, slow UI, or unmeasured conversions?
+- Who owns relevance decisions after launch: engineering, product, merchandising, content, support, or search team?
+- Are there seasonal campaigns, promotions, compliance constraints, or regional catalog differences?
+
+## Data And Governance
+
+- Which source system owns each record field?
+- What is the stable identifier for event attribution and updates?
+- How frequently does each attribute change?
+- Which fields are searchable, filterable, display-only, ranking-only, secured, or internal?
+- Are there locales, currencies, tenants, channels, regions, or permissions that require separate records, indices, filters, or secured API keys?
+- Do we need a backfill, incremental updates, partial updates, or full reindex pipeline?
+
+## UX Context
+
+- Does the UI need a full search results page, browse/category page, autocomplete, federated search, recommendations module, or all of these?
+- Which refinements should users see, and which should be applied silently?
+- Should query and refinements be shareable in the URL?
+- What should happen on empty results, unavailable products, hidden content, or misspellings?
+- What are the mobile filter, sort, and autocomplete expectations?
+
+## Measurement Context
+
+- Which events define success: click, view, add-to-cart, purchase, lead, signup, save, download, support deflection, or custom conversion?
+- Are queryID and hit position available at the point where the event fires?
+- How is userToken assigned across anonymous and logged-in sessions?
+- Which downstream features need events: analytics, A/B testing, personalization, Recommend, dynamic re-ranking, or query categorization?
+
+## Customer Handoff Brief
+
+Use this when the customer needs a practical plan more than a technical deep dive.
+
+- What platform or source system owns the searchable content: commerce platform, CMS, PIM, database, spreadsheet export, API, or mixed sources?
+- Who can change data feeds, frontend code, backend checkout or lead flows, analytics tags, and Algolia settings?
+- What environments exist: production only, staging, local, sandbox Algolia app, or temporary test index?
+- What sample data can be shared safely: 5 representative records, 5 edge-case records, current settings, screenshots, top searches, or event payloads?
+- What is the first useful milestone: searchable data, working filters, click events, conversion events, relevance tuning, UI launch, or AI readiness?
+- What work can be done with configuration and content decisions, and what work definitely needs code access?
+
+Customer-facing output:
+
+- One short summary of the goal.
+- Missing access or source material.
+- The smallest useful next step.
+- The owner needed for each next step.
+- A plain-language risk if the step is skipped.
+
+## Source Notes
+
+- Algolia records should contain information useful for searching, display, sorting, and relevance: https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data
+- Relevance improvement starts with searchable attributes and custom ranking, then expands to rules, synonyms, facets, analytics, and A/B testing: https://www.algolia.com/doc/guides/managing-results/relevance-overview
+- Event requirements and event types differ by feature: https://www.algolia.com/doc/guides/sending-events/concepts/event-types

--- a/skills/algolia-events-insights/SKILL.md
+++ b/skills/algolia-events-insights/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: algolia-events-insights
+description: >
+  Algolia event instrumentation guidance for Insights, analytics, personalization, Dynamic Re-Ranking, Recommend, and merchandising feedback loops. Use for search, autocomplete, browse, ecommerce, personalization, recommendations, or analytics instrumentation. Makes event decisions explicit before an Algolia UI is considered ready. Use when implementing or auditing clickedObjectIDsAfterSearch, convertedObjectIDsAfterSearch, viewedObjectIDs, addedToCartObjectIDsAfterSearch, purchasedObjectIDsAfterSearch, userToken, queryID, eventName, eventSubtype, or frontend/backend event pipelines. Do NOT use for live analytics retrieval, top-query inspection, or account-aware diagnostics; use algolia-mcp. Do NOT use for framework-specific InstantSearch or Autocomplete APIs; use the official instantsearch skill alongside this planning and validation skill.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.5"
+---
+
+# Algolia Events Insights
+
+Use this skill whenever user behavior needs to power analytics, personalization, Recommend, dynamic re-ranking, or measurable search quality.
+
+## Customer-Facing Standard
+
+- Start with one validated result-click event and one validated primary conversion before expanding.
+- State which owner controls each event: frontend, backend, analytics/tag manager, or data pipeline.
+- Use public `academy.algolia.com` for learning alignment and public `algolia.com/doc` for current implementation guidance when source-backed context is needed.
+- When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
+- Do not require custom Academy/docs access; use customer-provided sources only as optional context.
+- When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
+- Produce an event taxonomy, payload checklist, duplicate-event rule, and validation plan.
+- Distinguish between events that are merely ingestible and events that are usable by analytics, Dynamic Re-Ranking, NeuralSearch, Recommend, personalization, or revenue reporting.
+- Choose the implementation path deliberately: InstantSearch/search-insights first when possible, GTM for constrained marketing-managed frontends, Segment/CDP for centralized pipelines, and backend ownership for final server-side conversions.
+
+## Official Companion Skills
+
+- Use official `algolia-mcp` for live analytics signals such as top searches, no-result rates, click positions, no-click searches, and outcome metrics.
+- Use official `instantsearch` when event wiring belongs in InstantSearch or Autocomplete implementation code.
+- Use this skill after the official tool call to produce the event taxonomy, ownership model, payload checks, and feature-readiness notes.
+
+## Search UI Event Decision Point
+
+If the task includes a search results page, autocomplete, browse page, recommendations, personalization, Dynamic Re-Ranking, or ecommerce search:
+
+- Produce an event taxonomy before or during implementation when practical.
+- Plan events for every result interaction that the UI supports.
+- If event instrumentation is not implemented now, document the user-approved deferral, owner, risk, and validation follow-up in the completion summary.
+
+Required output:
+
+- `userToken` strategy.
+- Event names.
+- Event types.
+- Source UI surface.
+- Required Algolia fields: `index`, `objectID`, `queryID`, and `position` where the event type requires them.
+- Implementation location.
+- Validation method.
+
+For demos and prototypes, still produce a lightweight event table with planned events, deferred production concerns, and validation steps.
+
+## Source-Of-Truth Rules
+
+- Verify the current event method and required fields in public docs or the official implementation skill before writing code.
+- Do not use an `AfterSearch` method unless the interaction is explicitly attributable to an Algolia search or browse response and has a valid `queryID`.
+- If a conversion cannot include `queryID`, decide whether Algolia can infer attribution from a prior click. If not, use the non-AfterSearch method and state the analytics or feature limitation.
+- A 200 response, network success, or Debugger visibility proves ingestion only. Do not call the event setup ready until the payload is complete, consistent, attributed, and eligible for the intended downstream feature.
+- Treat generic views and filter interactions as weak signals unless the selected feature or personalization strategy explicitly needs them. Do not let weak P2 events distract from search-attributed clicks and conversions.
+
+## Workflow
+
+1. Read `references/events-guide.md` before adding or changing event code.
+2. Read `references/example-output.md` when producing an event taxonomy or customer-facing event setup plan.
+3. Read `references/search-event-taxonomy.md` when producing a search, browse, autocomplete, recommendations, or ecommerce event taxonomy.
+4. Separate the business path from the technical path. Business users define what to track, why it matters, KPIs, surfaces, and success criteria. Technical users implement schema, queryID propagation, identity consistency, validation, and monitoring.
+5. Start with the simple event plan: search result click, result view when needed, primary conversion, and add-to-cart or purchase when relevant.
+6. Prioritize with P0/P1/P2. P0 is search-attributed clicks plus the primary conversion. P1 adds important outcomes such as add-to-cart, purchase, lead, save, support resolution, or recommendation interactions. P2 adds optional or context-specific signals such as generic views or filter interactions.
+7. Identify which downstream features need events: analytics only, A/B testing, personalization, Recommend, dynamic re-ranking, merchandising, NeuralSearch evaluation, or Agent Studio feedback.
+8. Confirm the user identity strategy before implementation. Anonymous and authenticated user tokens must be consistent enough to join behavior.
+9. Preserve search attribution. Events after search must include `queryID`, `objectIDs`, `positions` when required, `index`, and the same user token used for the search.
+10. Select the implementation path and document connector risks: InstantSearch/search-insights, custom frontend, GTM, Segment/CDP, backend, or hybrid.
+11. Validate in a non-production environment before launch using arrival, usability, and attribution checks.
+12. Add a regression check after releases that touch UI structure, routing, identity, checkout, backend workflows, or analytics connectors.
+
+## Simple Implementation Recipe
+
+Use this order unless the app has unusual constraints:
+
+1. Turn on queryID retrieval for searches that produce clickable results.
+2. Set one durable anonymous `userToken`, then decide how it maps after login.
+3. Send click events from result cards using the hit's `objectID`, `index`, `queryID`, and displayed position.
+4. Send the primary conversion event from the place the conversion actually happens.
+5. Add cart, purchase, lead, save, or support-deflection events only when they map to a real business outcome.
+6. Test the network payload, Events Health, Debugger, user timeline where available, and destination or feature eligibility before calling the setup complete.
+
+Prefer a minimum viable event setup over a large taxonomy. For most customers, the first useful milestone is one validated result-click event and one validated primary conversion event with the same `userToken`, correct `objectID`, correct `index`, and `queryID` when search attribution applies.
+
+## Questions To Ask
+
+- Which conversions matter: view, click, add to cart, purchase, lead, signup, content save, support deflection?
+- Which Algolia-powered surfaces need events: search page, category/browse page, autocomplete, product detail page reached from search, recommendations, content search, support search, or agent experiences?
+- Which events are P0, P1, and P2 for this business goal?
+- Are events sent from the browser, backend, or both?
+- Which implementation path fits this stack: InstantSearch/search-insights, custom frontend, GTM, Segment/CDP, backend, or hybrid?
+- How is `userToken` assigned before and after login?
+- Can the UI access the `queryID` and hit position from the search response?
+- Are purchases or other conversions available only server-side?
+- Which indices and objectIDs should events reference when the same item appears in multiple indices or replicas?
+- What should prevent duplicate events when frontend tags, backend conversions, GTM, or Segment all observe the same action?
+- What validation surface will prove the event is not only received, but usable by the intended feature?
+
+## Implementation Standards
+
+- Use search-attributed event methods for actions caused by search results.
+- Do not invent a new `userToken` per event or page load.
+- Use stable, descriptive `eventName` values that business teams can read in reports.
+- Include price, quantity, currency, and object data where the selected event type supports it and the business needs revenue analysis.
+- Avoid double counting by deciding whether frontend, backend, or a deduped pipeline owns each event.
+- Treat a 200 response or visible Debugger event as ingestion proof, not usefulness proof. A valid event can still be unusable for downstream features if it has stale queryID, mismatched objectID, inconsistent userToken, missing position, weak signal type, or duplicate ownership.
+- Preserve the exact record identity from the search result. If the user clicked or converted on a variant, do not send a parent product ID unless the original search result used that same parent objectID.
+- Explain deduplication risk in customer language: repeated events from the same user on the same record may not all count toward downstream models, and a hardcoded shared userToken can make many users look like one user.
+- Positions are one-based. If positions are computed manually from an array index, add 1 and validate against the rendered result order.
+- Validate the full journey, not isolated events: search or browse request, click, add-to-cart or primary conversion, purchase or final outcome.
+- For Segment/CDP or GTM paths, validate both the source payload and the transformed Algolia payload because mappings may rename, flatten, drop, duplicate, or mis-shape fields.
+
+## Anti-Patterns
+
+- Building a large taxonomy before one click and one primary conversion are validated.
+- Over-investing in P2 events such as broad view or filter interactions before P0 search-attributed clicks and conversions are healthy.
+- Sending events from a tag manager that cannot access the actual `objectID`, `queryID`, position, index, or stable userToken.
+- Mixing frontend and backend purchase events without a deduplication rule.
+- Reusing stale queryIDs long after the search context is gone.
+- Treating events as optional for analytics quality, personalization, Recommend, dynamic re-ranking, Agent Studio feedback, or rollout measurement.
+- Calling filter clicks or broad view events AI-ready signals while P0 result clicks or conversions are missing.
+- Validating only one system in a connector path, such as Segment Debugger but not Algolia Debugger, or browser Network but not Events Health.
+- Sending SKUs, parent IDs, or external IDs when Algolia expects the exact `objectID` returned in the hit.
+
+## Completion Checkpoints
+
+Before calling an implementation ready, or when handing off a prototype with follow-ups, state whether these checkpoints are satisfied, deferred, or unknown:
+
+- `userToken` strategy status.
+- Hit click attribution status for `queryID`, `objectID`, `index`, and displayed position.
+- Autocomplete direct-result click versus query suggestion selection status.
+- Conversion event status: planned, implemented, validated, deferred, or unknown.
+- Event ownership and duplicate-event rule status.
+- Validation step status.
+- Implementation path selected and connector-specific risks documented.
+- Usability status: arrived, payload complete, attribution intact, feature destination or eligibility checked.
+- Regression plan for future UI, route, identity, checkout, or connector changes.
+
+## Academy And Customer Education Alignment
+
+When source-backed guidance is needed, search public Academy sources for Insights, analytics, and AI-readiness learning objectives and public Algolia docs for queryID, userToken, event methods, personalization, Recommend, and dynamic re-ranking details. Use source guidance to build a customer-appropriate event taxonomy, maturity plan, and validation path.
+
+## Maturity Behavior
+
+- Beginner implementation: implement one result-click event and one primary conversion event with a durable `userToken`.
+- Production readiness: validate payloads, ownership, duplicate prevention, backend conversions, and downstream visibility.
+- Optimization: connect events to analytics, A/B testing, personalization, Recommend, merchandising, and dynamic re-ranking decisions.
+- AI readiness: prove the event setup can support NeuralSearch evaluation, Agent Studio feedback, AI assistant quality measurement, and conversion attribution.
+
+## Output Contract
+
+Return a prioritized Event Plan, Connector Recommendation, Developer Handoff Sheet, code changes or owner handoff steps, and a validation plan. For audits, report missing attribution, identity inconsistencies, duplicate-event risks, weak-signal overinvestment, connector mapping risks, and downstream feature blockers first. Make the first recommendation small enough that a team can implement it in one sprint.

--- a/skills/algolia-events-insights/agents/openai.yaml
+++ b/skills/algolia-events-insights/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia Events Insights"
+  short_description: "Implement Algolia click and conversion events"
+  default_prompt: "Use $algolia-events-insights to plan and implement Algolia Insights events for search, analytics, and personalization."

--- a/skills/algolia-events-insights/evals/evals.json
+++ b/skills/algolia-events-insights/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "algolia-events-insights",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We want to turn on Personalization and eventually Dynamic Re-Ranking for our beauty products search (React + react-instantsearch, index: beauty_catalog). Zero events implemented today. My PM drafted a list of 23 events including every filter click, scroll depth, and hover. Where do we start?",
+      "expected_output": "The response rejects starting with a 23-event taxonomy: the first milestone is one validated result-click event and one validated primary conversion with a consistent userToken, correct objectID/index, and queryID where search-attributed. It prioritizes with P0/P1/P2, classifying filter clicks/hovers as weak P2 signals that should not precede healthy P0 events, asks about or defines the userToken strategy (anonymous token durability and post-login mapping) before calling anything ready, recommends the InstantSearch/search-insights path for this stack, and produces an event plan with validation steps beyond a 200 response.",
+      "files": [],
+      "expectations": [
+        "Recommends starting with one validated result-click event and one validated primary conversion event rather than the 23-event taxonomy",
+        "Prioritizes events as P0/P1/P2 and classifies filter clicks, hovers, and scroll depth as weak P2 signals not to over-invest in before P0 is healthy",
+        "Asks about or states an assumption for the userToken strategy (durable anonymous token, login mapping) before marking events ready",
+        "Requires queryID, objectID, index, and position attribution for search-attributed click events",
+        "Recommends the InstantSearch/search-insights implementation path given the react-instantsearch stack",
+        "Defines validation beyond ingestion (payload completeness, attribution, feature eligibility), not just a 200 response or Debugger visibility"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Audit request: our purchase conversions look doubled in Algolia. We send purchasedObjectIDsAfterSearch from the checkout thank-you page via GTM, AND our order service sends a backend purchase event. Also GTM sends the SKU from the dataLayer as objectID but our index uses productId_variantId as objectID. userToken is hardcoded to 'website-user' in the GTM tag. Index: shop_main.",
+      "expected_output": "The audit leads with the blockers: duplicate purchase events with no deduplication ownership rule between GTM and backend; SKU sent where Algolia expects the exact objectID returned in the hit (productId_variantId), making events unusable; and the hardcoded shared userToken making all users look like one user, which breaks personalization and downstream models. It also questions whether the GTM tag can access a valid queryID for the AfterSearch method. It recommends validating both the GTM source payload and the transformed Algolia payload, and produces a dedup rule assigning single ownership per event.",
+      "files": [],
+      "expectations": [
+        "Identifies the frontend GTM + backend double-send as a duplicate-event problem and assigns a single deduplication owner per event",
+        "Flags sending the SKU instead of the exact objectID (productId_variantId) returned in the hit as breaking attribution/usability",
+        "Flags the hardcoded shared userToken 'website-user' as making many users look like one user and breaking personalization and downstream features",
+        "Questions queryID validity/availability for the AfterSearch purchase method on the thank-you page, or proposes the non-AfterSearch method with the stated limitation",
+        "Recommends validating both the GTM/source payload and the transformed Algolia payload (connector mapping risk), not just one system",
+        "Distinguishes events that are ingestible from events that are usable by downstream features"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Dev says events are 'done' - he sees click events landing in the Algolia Events Debugger with 200s. But our Click-Through Rate analytics still show nothing and positions look wrong (we see position 0 a lot). Clicks are wired from a custom results grid, positions computed from the array index. What's going on?",
+      "expected_output": "The response explains that Debugger visibility and 200 responses prove ingestion only, not usability: analytics need complete, attributed payloads. It diagnoses position 0 as the one-based position bug — positions computed from a zero-based array index must add 1 and be validated against rendered order — and checks the rest of the attribution chain (clickAnalytics/queryID retrieval enabled, consistent userToken between search and event, exact objectID and index). It prescribes a validation plan covering the full journey and does not call the setup ready until attribution is intact.",
+      "files": [],
+      "expectations": [
+        "States that a 200 response or Debugger visibility proves ingestion only, not that events are usable by analytics",
+        "Diagnoses position 0 as a one-based position error: add 1 to zero-based array indexes and validate against the rendered result order",
+        "Checks queryID retrieval (clickAnalytics) and that the click event carries the same queryID/userToken as the originating search",
+        "Verifies objectID and index correctness against the actual hit rather than assuming the custom grid preserved them",
+        "Proposes validating the full journey (search, click, conversion) rather than isolated events, before calling the setup ready"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-events-insights/references/events-guide.md
+++ b/skills/algolia-events-insights/references/events-guide.md
@@ -1,0 +1,337 @@
+# Events Guide
+
+## Contents
+
+- [Fast Path](#fast-path)
+- [Academy Coaching Model](#academy-coaching-model)
+- [Event Readiness Model](#event-readiness-model)
+- [Implementation Path Selector](#implementation-path-selector)
+- [Low-Dev Implementation Path](#low-dev-implementation-path)
+- [Connector-Specific Handoff Questions](#connector-specific-handoff-questions)
+- [Code Pattern References](#code-pattern-references)
+- [Validation Workflow](#validation-workflow)
+- [Agent Checklist](#agent-checklist)
+- [Event Taxonomy Template](#event-taxonomy-template)
+- [Common Event Choices](#common-event-choices)
+- [Feature Readiness Signals](#feature-readiness-signals)
+- [Attribution Rules](#attribution-rules)
+- [Valid But Not Useful Enough](#valid-but-not-useful-enough)
+- [Common Failure Patterns](#common-failure-patterns)
+- [Identity Strategy](#identity-strategy)
+- [QA](#qa)
+- [Source Notes](#source-notes)
+
+## Fast Path
+
+For most implementations, start with this smallest useful setup:
+
+| Moment | Event | Owner | Required attribution |
+| --- | --- | --- | --- |
+| User clicks a search or browse result | `clickedObjectIDsAfterSearch` | Frontend | index, objectID, queryID, position, userToken |
+| User converts after search | `convertedObjectIDsAfterSearch` or a more specific conversion method | Frontend or backend | index, objectID, queryID for explicit search attribution, userToken |
+| User adds to cart | `addedToCartObjectIDsAfterSearch` when caused by search | Frontend or backend | index, objectID, queryID, userToken, price/quantity when available |
+| User purchases | `purchasedObjectIDsAfterSearch` when caused by search | Backend preferred | index, objectID, per-item `queryID` inside `objectData` for explicit search attribution because purchased items can come from different searches, userToken, revenue fields when available |
+| User views a product/content item outside search | `viewedObjectIDs` | Frontend | index, objectID, userToken |
+
+Do not begin with every possible event. Begin with the actions that unlock the customer's stated goal, then expand after the first payloads are validated.
+
+## Academy Coaching Model
+
+Events work best when the agent teaches both sides of the implementation:
+
+- Business users define what to track and why: KPIs, required user actions, affected Algolia-powered surfaces, priority, and success criteria.
+- Technical users define how tracking works: event method, payload schema, queryID propagation, userToken strategy, objectID source, frontend/backend owner, validation, and monitoring.
+
+When a customer asks for event setup, produce both outputs:
+
+- Event Plan: business-readable priority list of P0, P1, and P2 events mapped to surfaces and outcomes.
+- Developer Handoff Sheet: technical payload requirements, field sources, owner, trigger, deduplication rule, and validation steps.
+
+## Event Readiness Model
+
+Teach customers that an event can arrive successfully and still fail to power analytics or AI features. Validation has three layers:
+
+| Layer | Question | Evidence |
+| --- | --- | --- |
+| Arrival | Did Algolia receive the event? | Network response, server log, Events Health, or Debugger entry |
+| Usability | Are required fields present and shaped correctly? | `eventName`, event type/subtype, `index`, `objectIDs`, `userToken`, `queryID` for post-query events, `positions` where required |
+| Attribution | Is the event tied to the right search, item, and user? | Same `queryID` from search to click to conversion, same durable `userToken`, exact Algolia `objectID`, one-based position, no duplicate owner |
+
+Do not mark an event setup ready from arrival alone. A 200 response, successful tag fire, Segment debugger event, or Algolia Debugger entry is only the first layer.
+
+## Implementation Path Selector
+
+Choose the path before writing code or building tags. The best path depends on where the required attribution fields are available.
+
+| Path | Use when | Strengths | Risks to validate |
+| --- | --- | --- | --- |
+| InstantSearch plus search-insights | The UI is built with InstantSearch or can use its event helpers/middleware | Simplest starting point; queryID and hit context are close to the user action; fewer custom mappings | Ensure `clickAnalytics` and `userToken` are configured; validate custom conversions beyond automatic events |
+| Custom frontend with Insights API | The app owns rendering and can access search responses | Full control over payloads and timing | Manual position calculation, stale queryID, objectID mismatch, token resets |
+| Google Tag Manager | Marketing-managed frontend, limited code deploys, shared analytics tagging | Fast iteration and broad template coverage | Variables may not contain hit `objectID`, `queryID`, position, or durable `userToken`; duplicate triggers are common |
+| Segment or CDP | Centralized identity and event pipeline, multi-platform analytics, server-side purchase confirmation | Stronger identity governance and backend conversion support | Mappings may rename/drop fields; anonymous ID and userToken may diverge; source debugger can pass while Algolia payload fails |
+| Backend events | Purchase, lead acceptance, support resolution, subscription, or other final conversion is server-side | Reliable final outcome and revenue data | Must persist search attribution or infer from prior click; avoid duplicate frontend/backend final conversions |
+| Hybrid | Clicks happen in the frontend but final conversions happen later or server-side | Matches many commerce architectures | Requires explicit handoff of `queryID`, `objectID`, `index`, and `userToken` across pages and systems |
+
+Output requirement:
+
+- Recommend one primary path and one fallback path.
+- Name where each required field comes from.
+- State the expected debugging surface: browser Network, GTM preview, Segment debugger, backend logs, Events Health, Algolia Debugger, or user timeline.
+- State the duplicate-prevention rule.
+
+### P0/P1/P2 Priority Model
+
+Use this model to keep event setup simple:
+
+- P0 must-have: result clicks and primary conversions after search or browse, with `queryID`, `userToken`, `objectID`, `index`, and position when required.
+- P1 important: add-to-cart, purchase, lead, save, support resolution, recommendation interactions, or other business outcomes that unlock additional measurement and optimization value.
+- P2 nice-to-have: context-specific or weaker signals such as broad views, filter interactions, or secondary engagement events. Add these after P0 is validated.
+
+Do not let customers start with a giant taxonomy. Teach them that healthy P0 events usually create more value than many loosely defined P2 events.
+
+## Low-Dev Implementation Path
+
+Use this path when the customer has limited engineering access.
+
+1. Identify the one search UI flow and one conversion flow that matter most.
+2. Confirm whether the frontend exposes `objectID`, `index`, `queryID`, result position, and `userToken` to the browser or data layer.
+3. If a tag manager is used, only use it when those values are available at the exact interaction moment and duplicate events can be prevented.
+4. If purchase, lead acceptance, support resolution, or subscription completion happens server-side, ask for the backend owner. A browser-only tag is usually not enough for reliable final conversions.
+5. Produce an owner handoff table: field needed, where it should come from, who can expose it, and how to validate it.
+
+Minimum viable validation:
+
+- One click event from a search result has correct `index`, `objectID`, `queryID`, `position`, and `userToken`.
+- One primary conversion event uses the same identity and record identifiers.
+- Refreshing, navigating, or logging in does not create a new unrelated token unless that is the intended identity policy.
+- Repeating the flow does not double-send the same event from both frontend and backend.
+
+## Connector-Specific Handoff Questions
+
+### InstantSearch Or Search Insights
+
+- Is `clickAnalytics` enabled for searches that produce clickable results?
+- Is the Insights client initialized once?
+- Is the same `userToken` used for searches and events?
+- Which events are automatic, and which require manual `sendEvent` or equivalent handling?
+- Do custom conversion events preserve the originating `queryID`?
+
+### Google Tag Manager
+
+- Where does `queryID` come from, and is it available at the exact click or conversion moment?
+- Which data layer variable contains the Algolia `objectID`, not a SKU or parent product ID?
+- How is `userToken` defined and reused across templates?
+- Which triggers could fire twice?
+- Does GTM preview show the same payload shape that Algolia receives?
+
+### Segment Or CDP
+
+- Which Segment identifier maps to Algolia `userToken`: anonymous ID, user ID, or a custom field?
+- Are `queryID`, `objectIDs`, and `positions` mapped with the exact property names expected by the Algolia destination?
+- Are arrays preserved as arrays, not flattened strings?
+- Does the Segment debugger event match the Algolia Debugger event after transformation?
+- Is server-side purchase attribution linked to the original frontend click or search context?
+
+### Backend Conversion Flow
+
+- What frontend action captures the `queryID`, `objectID`, `index`, and `userToken` before navigation or checkout?
+- How are those values stored through cart, checkout, account creation, or payment?
+- What is the maximum delay between search and conversion, and does the event still qualify as search-attributed?
+- Which owner sends the final conversion, and what prevents frontend and backend duplicates?
+
+## Code Pattern References
+
+Use these as implementation shapes, then adapt to the local project and current Algolia docs.
+
+### React InstantSearch Result Click
+
+1. Enable click analytics for searches that render clickable hits.
+2. Use the InstantSearch event helpers or middleware when available.
+3. Send the click from the hit component, using the hit's objectID, index, queryID, and rendered position.
+
+Implementation checklist:
+
+- The hit component receives or can derive `objectID`.
+- The search response includes `queryID`.
+- The UI knows the displayed position for the clicked hit.
+- The same `userToken` is used on the search request and the click event.
+
+### Vanilla JavaScript Search Result Click
+
+1. Store the search response `queryID` with rendered hits.
+2. Render each hit with its `objectID`, `index`, and position.
+3. On click, send the search-attributed click event before or alongside navigation.
+4. Avoid recomputing position after filtering or client-side sorting.
+
+### Backend Purchase Or Lead Conversion
+
+Use backend ownership when the conversion is finalized server-side, such as purchase, lead acceptance, subscription, or support case resolution.
+
+Capture at the time of user action:
+
+- `userToken`
+- `objectID`
+- `index`
+- `queryID` when using an `AfterSearch` conversion method for explicit search attribution; purchase events carry the `queryID` per item inside `objectData` rather than at the top level
+- price, quantity, currency, or conversion metadata when relevant
+
+Then send the final conversion from the backend with the same identity and record identifiers. Decide whether the frontend sends an intermediate event, such as add-to-cart, to avoid duplicate purchase conversions.
+
+### Validation Payload Example
+
+Every validated event should be explainable in plain language:
+
+- Event name: business-readable action.
+- Method: click, conversion, view, add-to-cart, or purchase.
+- Index: the index or replica that produced the interaction.
+- ObjectIDs: records the user interacted with.
+- queryID: present for search-attributed interactions.
+- positions: present when the method requires ranking position.
+- userToken: stable anonymous or authenticated identity.
+- Owner: browser, backend, or deduped pipeline.
+
+## Validation Workflow
+
+Validate a complete journey, not isolated events:
+
+1. Perform a search or browse request that returns a `queryID`.
+2. Record the `userToken` used on the search.
+3. Click a result and verify `eventType`, `eventName`, `index`, exact `objectID`, one-based `position`, `queryID`, and `userToken`.
+4. Trigger add-to-cart or the primary conversion.
+5. Compare the conversion `queryID` to the original search/click `queryID`.
+6. Confirm the same `userToken` ties search, click, and conversion together.
+7. Inspect Events Health or Debugger for warnings, errors, destination/feature eligibility, and user timeline continuity when available.
+8. Repeat the journey once to check duplicates.
+9. Test a non-search path and confirm it uses a non-AfterSearch method or has a documented attribution choice.
+
+Troubleshoot in this order:
+
+1. Missing or incorrect `queryID`.
+2. Inconsistent `userToken`.
+3. Incorrect, missing, or non-index `objectID`.
+4. Incorrect `positions`, especially zero-based positions.
+5. Timing or attribution-window issues.
+6. Duplicate frontend/backend/tag/CDP ownership.
+7. Weak event type overinvestment, such as filter clicks without P0 result clicks.
+
+## Agent Checklist
+
+1. Ask what business outcome the event should prove.
+2. Locate where the search response provides `queryID`, hit `objectID`, and displayed position.
+3. Locate where the app stores or can create `userToken`.
+4. Decide whether browser or backend owns each event.
+5. Implement one flow end to end before adding more event types.
+6. Validate payloads in the browser/network tab or server logs.
+7. Confirm events appear in the relevant Algolia debugging, analytics, or feature-readiness surface when available.
+
+## Event Taxonomy Template
+
+Create a table with:
+
+- User action.
+- Algolia event method.
+- `eventName`.
+- Index.
+- ObjectIDs source.
+- QueryID source.
+- Position source.
+- UserToken source.
+- Frontend/backend owner.
+- Deduplication rule.
+- Downstream feature unlocked.
+
+## Common Event Choices
+
+- Search result click: `clickedObjectIDsAfterSearch`.
+- Search-attributed conversion: `convertedObjectIDsAfterSearch`.
+- Search-attributed add to cart: `addedToCartObjectIDsAfterSearch`.
+- Search-attributed purchase: `purchasedObjectIDsAfterSearch`.
+- Non-search result interaction: use the corresponding method without `AfterSearch`.
+- Product/content view unrelated to a prior search: `viewedObjectIDs`.
+- Filter interactions: filter event methods when the feature requires them.
+
+## Feature Readiness Signals
+
+Map event types to the feature goal before implementation:
+
+| Feature goal | Stronger signals | Weak or supporting signals | Readiness note |
+| --- | --- | --- | --- |
+| Search analytics and A/B testing | Search-attributed clicks and conversions | Generic views | QueryID and userToken continuity matter for trustworthy rates |
+| Dynamic Re-Ranking | `clickedObjectIDsAfterSearch`, conversion events after search | Filter interactions | Needs enough events per query/record and deduplicates repeated user behavior |
+| NeuralSearch activation, evaluation, and optimization | Search-attributed clicks and conversions; add-to-cart and purchase when relevant | Broad views, filter clicks | Current public NeuralSearch docs do not require events for activation, but events guide semantic attribute selection and unlock retraining and Adaptive Intent. Verify current requirements before activation, then use stronger outcomes to measure and improve behavior. |
+| Recommend | Product clicks, add-to-cart, purchase, multi-item conversions where relevant | Generic page views | Model-specific minimums and event choices vary; verify current docs |
+| Personalization | Events with stable `userToken` | Events with regenerated or shared tokens | Identity continuity is the gate |
+| Revenue insights | Add-to-cart, purchase, lead, subscription, revenue-bearing conversions | Clicks alone | Validate price, quantity, currency, and final-conversion owner |
+
+## Attribution Rules
+
+- Set `clickAnalytics: true` on searches that need queryID attribution.
+- Keep the same `userToken` on the search request and the later event.
+- Preserve the exact `objectID` and `index` from the hit the user interacted with.
+- Send positions when required by the event method.
+- Events with queryID are time-sensitive. Current public docs state that click and conversion events with `queryID` must occur within one hour of the corresponding search request.
+- If a conversion cannot carry a queryID, validate whether Algolia can infer it from an earlier click with the same userToken, app, index, and objectID. Otherwise use the non-AfterSearch event method and state which downstream features may not count it.
+- Category pages powered by empty-query searches plus filters still need search-style event attribution when users interact with results.
+
+## Valid But Not Useful Enough
+
+Teach customers that an event can be accepted and still not help the feature they care about. Check for:
+
+- Weak signal: filter events and generic views may be valid but often do not carry the same downstream value as clicks and conversions tied to records.
+- Stale queryID: search-attributed events are time-sensitive and must use the queryID from the relevant search context.
+- ObjectID mismatch: the event objectID must match the record returned by the original search or browse response. Parent/variant mismatches can make the event unusable for attribution.
+- UserToken problem: a hardcoded, shared, or frequently regenerated token can make real user behavior impossible to interpret.
+- Duplicate ownership: frontend and backend events can double-count unless the taxonomy assigns one owner or a deduplication rule.
+
+Debugger visibility proves ingestion. Feature readiness requires the payload to be attributable, consistent, and meaningful.
+
+## Common Failure Patterns
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Event returns 200 but does not power target feature | Ingestible but not usable or not eligible for the feature | Check required fields and destination/feature eligibility |
+| Click event has position 0 | Position was copied from a zero-based array index | Send one-based positions, or use the hit/event helper when possible |
+| ObjectID validation fails | Event sends SKU, parent ID, variant ID, or URL instead of Algolia `objectID` | Use the exact `objectID` returned by the hit |
+| Conversion appears but is not attributed to search | Missing, stale, or mismatched `queryID` | Carry the originating queryID through click, PDP, cart, and conversion |
+| Personalization resets or feels generic | `userToken` changes between page views, login, or systems | Define anonymous/authenticated token policy and validate one user timeline |
+| Metrics look inflated | Duplicate events from frontend, backend, GTM, or CDP | Assign one owner per final event and add deduplication rules |
+| Segment or GTM looks correct but Algolia is wrong | Connector mapping renamed, flattened, or dropped fields | Validate both connector debugger and Algolia Debugger |
+| Events degrade after release | UI route, data layer, identity, or checkout changed | Add post-release event smoke checks |
+
+## Identity Strategy
+
+Ask how the product treats:
+
+- Anonymous sessions.
+- Login and logout.
+- Cross-device behavior.
+- Server-side purchases.
+- Consent restrictions.
+- Shared accounts.
+- B2B account switching.
+
+Do not generate a new random user token for every event. Use a durable anonymous token and connect or replace it deliberately on login according to the business and privacy requirements.
+
+## QA
+
+- Use a test index or staging app when possible.
+- Verify the browser/network payload, not only the source code.
+- Confirm events appear in Algolia debugging/analytics tools when available.
+- Trigger the same flow twice and check for unintended duplicate events.
+- Test query, browse/category, autocomplete, recommendation, and direct-navigation flows separately.
+- Filter the debugger by `userToken` and follow one complete journey from search to click to conversion.
+- Compare queryID from the original search response to the queryID on click and conversion events.
+- Inspect whether the event destination/readiness indicators match the intended downstream features.
+- After UI, routing, identity, checkout, analytics, or connector changes, re-run search to click to conversion.
+- Monitor event volume, freshness, validation warnings, duplicate patterns, and unexpected drops after release.
+- For multi-item purchases, confirm objectIDs, quantities, prices, and currency align by item.
+- For multi-index setups, confirm the event references the index that produced the hit or the documented aggregation strategy.
+
+## Source Notes
+
+- Algolia Insights supports click, conversion, and view events, and different features need different event types: https://www.algolia.com/doc/guides/sending-events/concepts/event-types
+- `AfterSearch` methods are for interactions tied to Algolia search or browse requests, require `queryID`, and are time-sensitive: https://www.algolia.com/doc/guides/sending-events/concepts/event-types
+- Algolia's implementation-path guide covers frontend, ecommerce platform, CDP/tag manager, manual, batch, and external analytics options: https://www.algolia.com/doc/guides/sending-events/getting-started
+- InstantSearch has dedicated event guidance for click and conversion events: https://www.algolia.com/doc/guides/building-search-ui/events/js
+- Segment and connector paths must preserve Algolia event fields through mapping and transformation before the payload reaches Algolia: https://www.algolia.com/doc/guides/sending-events/connectors/segment
+- Google Tag Manager paths require search-related data attributes such as index, objectID, position, and queryID in the page templates: https://www.algolia.com/doc/guides/sending-events/connectors/google-tag-manager

--- a/skills/algolia-events-insights/references/example-output.md
+++ b/skills/algolia-events-insights/references/example-output.md
@@ -1,0 +1,82 @@
+# Example Output: Minimal Event Taxonomy
+
+Use this as a compact first event plan for a commerce search experience.
+
+## Goal
+
+Measure whether search and browse interactions lead to product engagement, add-to-cart, and purchase. Prepare the implementation for analytics, A/B testing, personalization, Recommend, dynamic re-ranking, and AI-readiness evaluation.
+
+## Event Map
+
+| User action | Algolia method | Event name | Owner | Required fields | Validation |
+| --- | --- | --- | --- | --- | --- |
+| P0: Search result click | `clickedObjectIDsAfterSearch` | `Product Clicked` | Frontend | `index`, `objectID`, `queryID`, one-based `position`, `userToken` | Browser payload includes queryID from the clicked hit; Algolia Debugger shows destination eligibility. |
+| P0: Primary conversion caused by search | `convertedObjectIDsAfterSearch`, `addedToCartObjectIDsAfterSearch`, or `purchasedObjectIDsAfterSearch` depending on the business goal | `Product Added To Cart` or `Product Purchased` | Frontend or backend | `index`, `objectID`, `queryID`, `userToken`, price/quantity when available | Same userToken and objectID as the search journey; queryID is current or documented with an inference path. |
+| P1: Purchase caused by search | `purchasedObjectIDsAfterSearch` | `Product Purchased` | Backend preferred | `index`, `objectID`, per-item `queryID` inside `objectData` for explicit search attribution, `userToken`, price, quantity, currency | Purchase event is not duplicated by frontend and backend; if queryID cannot be carried within the valid attribution window or inferred from a prior click, use the non-AfterSearch purchase method and document the feature impact. |
+| P2: Product view not caused by search | `viewedObjectIDs` | `Product Viewed` | Frontend | `index`, `objectID`, `userToken` | No queryID is used when the view is not search-attributed. Treat as supporting, not a replacement for P0 events. |
+
+## Connector Recommendation
+
+Primary path: InstantSearch plus search-insights for result clicks and add-to-cart because the UI has the hit `objectID`, `queryID`, position, and `userToken` at the interaction moment.
+
+Backend path: order confirmation should send final purchase events because revenue, quantity, and currency are finalized server-side.
+
+Fallback path: use GTM only if the data layer exposes `queryID`, exact Algolia `objectID`, one-based position, and durable `userToken` at click/conversion time. Use Segment only if mappings preserve arrays and field names into the Algolia destination.
+
+Duplicate rule: frontend may send click and add-to-cart; backend owns final purchase. Do not also fire a frontend purchase tag.
+
+## Identity Rule
+
+Create one durable anonymous `userToken` and use it on search requests and events. When the user logs in, either keep the anonymous token for continuity or map it deliberately to the authenticated identity according to the customer's privacy and analytics policy. Do not generate a new token per event or page view.
+
+## First Validation Pass
+
+1. Search for `trail running shoes`.
+2. Click the third result.
+3. Confirm the click payload includes the clicked hit's `objectID`, the result position, the response `queryID`, the index, and the same `userToken` used for search.
+4. Add the same product to cart.
+5. Confirm add-to-cart uses the same identity, record identifiers, and queryID because it is sent with an `AfterSearch` method.
+6. Complete a test purchase.
+7. Confirm only one purchase event is sent, and that an `AfterSearch` purchase includes a queryID within the valid attribution window or has a documented inference path from a prior click.
+
+Validation standard:
+
+- Arrival: event appears in Network/server logs and Algolia Debugger.
+- Usability: required fields are present, arrays are shaped correctly, and positions are one-based.
+- Attribution: one user timeline shows search to click to conversion with the same `userToken`, matching `queryID`, exact hit `objectID`, and no duplicate final conversion.
+
+## Developer Handoff Sheet
+
+| Field | Source | Owner | Validation |
+| --- | --- | --- | --- |
+| `queryID` | Search or browse response with click analytics enabled | Frontend search owner | Same value appears on click and search-attributed conversion. |
+| `objectID` | Hit returned by Algolia | Frontend/UI owner | Matches the record the user clicked or converted on; no parent/variant mismatch. |
+| `position` | Rendered hit position | Frontend/UI owner | Present on click events that require position. |
+| `userToken` | Durable anonymous/authenticated identity policy | Frontend/platform owner | One test journey can be filtered by the same token in the Debugger. |
+| Final purchase | Order service or backend conversion flow | Backend owner | Not duplicated by frontend purchase event. |
+
+## Feature Readiness Notes
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Search analytics | Ready after P0 click and conversion validate | QueryID and position power click and conversion analysis. |
+| Dynamic Re-Ranking | Planned | Needs enough search-attributed click/conversion volume and deduplicated user behavior. |
+| NeuralSearch evaluation | Planned | Events help measure quality, even when activation does not require events. |
+| Recommend | Planned | Validate current model-specific event requirements before relying on purchase or add-to-cart events. |
+| Personalization | Blocked until identity is validated | Stable `userToken` is the gate. |
+
+## Common Debugger Findings
+
+- Ingested but weak: generic view or filter events arrive, but P0 clicks/conversions are missing.
+- Ingested but unattributed: event is visible, but queryID is missing, stale, or different from the original search.
+- Ingested but mismatched: event objectID uses a parent product while the search returned a variant.
+- Ingested but mispositioned: result position is zero-based, so click position analysis is wrong.
+- Ingested but deduplicated: all users share one userToken, so downstream models see too little usable behavior.
+- Connector mismatch: Segment/GTM source event looks correct, but Algolia receives renamed, flattened, missing, or duplicate fields.
+
+## Follow-Up Questions
+
+- Which conversion is the business's primary success metric: purchase, lead, signup, save, download, or support deflection?
+- Are purchases finalized on the backend?
+- Are consent rules or account switching relevant?
+- Which AI or personalization features depend on this event setup?

--- a/skills/algolia-events-insights/references/search-event-taxonomy.md
+++ b/skills/algolia-events-insights/references/search-event-taxonomy.md
@@ -1,0 +1,38 @@
+# Search Event Taxonomy
+
+Use this template before or during a search, browse, autocomplete, recommendations, personalization, Dynamic Re-Ranking, or ecommerce implementation. Instantiate it for the actual UI surfaces, or explicitly mark events as implemented, validated, planned, deferred, or unknown.
+
+| Surface | User action | Event type | Event name | Required payload | Owner/path | Validation notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| Autocomplete | Product or content selected from Algolia hits | Click | Autocomplete Result Clicked | `eventName`, `index`, `objectIDs`, `queryID`, one-based `positions`, `userToken` | Frontend/search-insights | Direct result click. Use an after-search click only when the hit came from a search response with `queryID`. |
+| Autocomplete | Query suggestion selected | Search handoff | Query Suggestion Submitted | `query`, `source`, `userToken` | Frontend | Not an object click unless the suggestion is backed by a hit and preserves hit attribution. |
+| Search results page | Result clicked | Click | Search Result Clicked | `eventName`, `index`, `objectIDs`, `queryID`, one-based `positions`, `userToken` | Frontend/search-insights | Use `clickedObjectIDsAfterSearch`; validate exact hit objectID. |
+| Browse or category page | Result clicked | Click | Browse Result Clicked | `eventName`, `index`, `objectIDs`, `queryID`, one-based `positions`, `userToken` | Frontend/search-insights | Use after-search attribution when browse results include `queryID`; otherwise state the non-search attribution choice. |
+| Product detail page or content detail page | Result viewed after search | View | Search Result Viewed | `eventName`, `index`, `objectIDs`, `userToken` plus stored attribution when available | Frontend or connector | Use only if the view is a meaningful signal for the use case; do not substitute for P0 click/conversion. |
+| Cart, save, lead, or primary action | Product added, saved, or lead submitted | Conversion | Product Added To Cart | `eventName`, `index`, `objectIDs`, `queryID` when available, `userToken` | Frontend, GTM, Segment, or backend | Use the after-search method when the conversion is attributable to a search response; compare queryID to original search. |
+| Purchase or completed conversion | Purchase completed | Conversion | Product Purchased | `eventName`, `index`, `objectIDs`, `queryID` when available, `userToken`, `price`, `quantity`, `currency` where supported and needed | Backend preferred | Decide whether frontend, backend, or a deduped pipeline owns this event; validate no duplicate final conversion. |
+| Recommendations | Recommended result selected | Click | Recommendation Result Clicked | `eventName`, `index`, `objectIDs`, `userToken`, recommendation attribution fields required by current docs | Frontend/search-insights or custom | Validate against current Recommend event requirements. |
+
+## Key Decisions
+
+- Anonymous `userToken` strategy:
+- Authenticated `userToken` strategy:
+- Login merge behavior:
+- Event owner by surface:
+- Implementation path by surface:
+- Deduplication rule:
+- Connector mapping risks:
+- Deferred events and owner:
+- Validation method:
+
+## Readiness Checkpoints
+
+Before calling the event setup ready, state whether these checkpoints are satisfied, planned, deferred, or unknown:
+
+- Result clicks preserve `index`, `objectID`, `queryID`, `position`, and `userToken`.
+- Query suggestions and direct-result selections are tracked as different actions.
+- Conversion events are implemented, planned, or explicitly deferred by the user.
+- Validation evidence exists for network payloads and downstream visibility where available.
+- Events are checked for arrival, usability, and attribution, not only successful delivery.
+- GTM, Segment, backend, or hybrid paths have source payload and Algolia payload validation.
+- One complete user journey can be filtered by `userToken` from search to click to conversion.

--- a/skills/algolia-index-configuration/SKILL.md
+++ b/skills/algolia-index-configuration/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: algolia-index-configuration
+description: >
+  Algolia index settings and relevance configuration guidance. Use when configuring searchableAttributes, attributesForFaceting, customRanking, ranking, replicas, virtual replicas, rules, synonyms, typo tolerance, distinct, filters, optional filters, merchandising, browse/category relevance, or A/B-testable relevance changes. Do NOT use for live settings writes, backups, copies, or operational account tasks; use algolia-cli or algolia-mcp instead. Do NOT use for record-shape or variant strategy; use algolia-data-modeling instead.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.3"
+---
+
+# Algolia Index Configuration
+
+Use this skill when changing how Algolia ranks, filters, facets, merchandises, or sorts results. Relevance configuration should reflect the business outcome and the user's decision path.
+
+## Customer-Facing Standard
+
+- Capture the current settings or assumptions before recommending changes.
+- Tie every setting change to a business goal and representative query set.
+- Use public `academy.algolia.com` for learning alignment and public `algolia.com/doc` for current implementation guidance when source-backed context is needed.
+- When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
+- Do not require custom Academy/docs access; use customer-provided sources only as optional context.
+- When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
+- Produce settings, expected tradeoffs, rollback notes, and validation queries.
+- Produce a settings decision record that distinguishes deterministic constraints, ranking preferences, and query-specific merchandising.
+
+## Official Companion Skills
+
+- Use official `algolia-cli` for live settings, rules, synonyms, replicas, backups, or configuration changes.
+- Use official `algolia-mcp` for live search behavior, analytics, top searches, no-result queries, click positions, and recommendation evidence.
+- Use official A/B testing guidance or tools when an experiment is in scope; keep this skill focused on hypothesis, evidence, decision criteria, and rollback.
+- Use this skill after the official tool call to explain tradeoffs, test queries, rollback expectations, and customer-facing validation criteria.
+
+## Source-Of-Truth Rules
+
+- Do not change or recommend live settings without first capturing the current settings or stating that the plan is provisional.
+- Use official `algolia-cli` for settings, rules, synonyms, replicas, and backups; use this skill to design and explain the change.
+- Verify current docs or official skill guidance before relying on feature behavior such as replicas, virtual replicas, rules, optional filters, or A/B testing.
+
+## Workflow
+
+1. Read `references/configuration-guide.md` before editing settings.
+2. Capture current settings before modifying an existing index.
+3. Ask what good results mean for the use case: exactness, availability, popularity, margin, recency, location, personalization, editorial priority, or diversity.
+4. Classify each relevance lever: deterministic filter, textual match priority, tie-breaker, optional preference, query-specific rule, or explicit sort.
+5. Make the smallest coherent settings change and describe expected tradeoffs.
+6. Validate with representative queries, facet/filter combinations, query rules, sorts, and no-result cases.
+7. For material changes, write the hypothesis, baseline, success metric, experiment decision rule, and rollback trigger before launch.
+
+## Questions To Ask
+
+- Which queries or browse pages are most valuable or currently broken?
+- Which attributes should match first, and which should only help recall?
+- Which business metrics should break textual ties?
+- Which filters must be available to users, and which filters are applied silently?
+- Do sort orders need replicas, and are those sort orders allowed to weaken relevance?
+- Are synonyms and rules global, seasonal, category-specific, or campaign-specific?
+- Which constraints are non-negotiable filters, and which are preferences that can rank lower but still return results?
+- Which terms need typo protection or exact treatment, such as SKUs, part numbers, acronyms, postal codes, or regulated names?
+
+## Implementation Standards
+
+- Prefer ordered `searchableAttributes` that reflect the user's mental model.
+- Put numeric or boolean business signals in `customRanking`, not in frontend sort hacks.
+- Declare only needed `attributesForFaceting`; use searchable facets where users search inside facets.
+- Treat synonyms and rules as governed relevance assets. Name, scope, and test them.
+- Use replicas for explicit sort-by experiences and virtual replicas where relevant sorting fits the use case.
+- Avoid irreversible production changes without a settings backup or repeatable configuration file.
+- Keep deterministic constraints in filters or secured filters. Use optional filters only when a result may still be relevant without the preference.
+- Treat facet configuration as a user decision contract: declare only attributes users need to refine, choose searchable facets only when users search within values, and test counts after common refinements.
+- Use synonyms for genuine language equivalence. Use rules for bounded intent, promotions, redirects, or merchandising with a condition, owner, and review/expiry date.
+- Protect identifiers and exact-sensitive terms with current documented typo settings rather than weakening all search behavior.
+- Treat every sort choice as a relevance decision. Document the replica type, displayed sort label, expected loss of relevance, and whether filters/facets remain consistent.
+- Change one meaningful relevance variable per experiment. Do not infer causality when ranking, rules, data, and UI changed together.
+
+## Anti-Patterns
+
+- Tuning relevance with one anecdotal query instead of a representative query set.
+- Using synonyms to compensate for missing data or unrelated concepts.
+- Pinning or burying results globally when the intent is category, campaign, locale, or segment-specific.
+- Adding every possible facet, which slows decision-making and creates noisy filters.
+- Letting custom ranking overpower exact-match or permission-sensitive behavior without testing.
+- Using optional filters to enforce availability, permission, region, or compliance constraints that must never be violated.
+- Using synonyms where a scoped rule, data correction, or typo exception is the real solution.
+- Interpreting an A/B test before sufficient event-backed data and confidence exist, or stopping and restarting a test as if it were continuous.
+
+## Academy And Customer Education Alignment
+
+When source-backed guidance is needed, search public Academy sources for relevance learning objectives and public Algolia docs for searchable attributes, ranking, facets, synonyms, rules, replicas, merchandising, and A/B testing. Map the work to maturity level and use case, then turn source guidance into questions, test queries, and validation criteria rather than copied reference text.
+
+## Maturity Behavior
+
+- Beginner implementation: define the first coherent searchable attributes, facets, and ranking signals from the customer journey.
+- Production readiness: capture settings backup, deterministic-versus-optional filter decisions, representative query set, rollback notes, secured filters, and launch-impact checks.
+- Optimization: require baseline queries, analytics signals, one-variable A/B-test plan, merchandising scope, confidence interpretation, and expected before/after behavior.
+- AI readiness: preserve deterministic filters, secured data, business rules, and measurement while validating NeuralSearch or Agent Studio dependencies.
+
+## Output Contract
+
+Return settings changes as code or JSON, a settings decision record, relevance intent, test queries, and assumptions requiring business review. Include before/after expectations for top queries, hard/optional constraint behavior, experiment criteria, and rollback triggers when relevance changes are material.

--- a/skills/algolia-index-configuration/agents/openai.yaml
+++ b/skills/algolia-index-configuration/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia Index Configuration"
+  short_description: "Configure relevance, ranking, and settings"
+  default_prompt: "Use $algolia-index-configuration to configure Algolia index settings, ranking, facets, synonyms, rules, and replicas."

--- a/skills/algolia-index-configuration/evals/evals.json
+++ b/skills/algolia-index-configuration/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "algolia-index-configuration",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Our furniture store index (furniture_prod, ~15k records) has terrible relevance. Searching 'oak table' returns oak chairs first because 'oak table runner' matches in the description. Attributes we have: name, description, category, material, brand, price, rating, stock_status. Can you set up searchableAttributes and ranking properly?",
+      "expected_output": "The response first captures current settings (or explicitly marks the plan as provisional), then proposes ordered searchableAttributes reflecting the user's mental model (e.g. name and category/material before description), puts business signals like rating in customRanking rather than frontend hacks, ties the change to representative queries ('oak table' plus others, not one anecdote), and returns settings as code/JSON with expected tradeoffs, validation queries, and rollback notes. Any live settings write is routed to algolia-cli or algolia-mcp.",
+      "files": [],
+      "expectations": [
+        "Captures or asks for the current index settings before recommending changes, or explicitly labels the plan provisional",
+        "Proposes ordered searchableAttributes with higher-priority attributes (e.g. name, category, material) above description, and explains the ordering rationale",
+        "Places numeric/boolean business signals (e.g. rating, stock_status) in customRanking rather than suggesting frontend sort hacks",
+        "Warns against tuning from the single 'oak table' anecdote and proposes a representative query set for validation",
+        "Returns concrete settings as code or JSON plus expected tradeoffs, test queries, and rollback notes",
+        "Routes the live settings write to algolia-cli or algolia-mcp instead of claiming to apply it directly"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Merchandising wants: when someone searches 'clearance' show only discounted items, and they also want us to add a synonym so 'couch' = 'sofa' = 'sectional'. Also legal says out-of-region products must NEVER appear for EU users. We currently handle the EU thing with an optionalFilter someone added last year. Index is home_goods_prod.",
+      "expected_output": "The response classifies each lever correctly: the EU restriction is a deterministic constraint that must be a hard filter or secured filter — flagging the existing optionalFilters usage as a compliance bug, since optional filters can still return non-matching results; 'clearance' intent is a scoped, governed Rule (with condition, owner, review/expiry), not a synonym; couch=sofa is genuine language equivalence suitable for a synonym, while sectional is questionable equivalence worth challenging. Live rule/synonym/settings changes are routed to algolia-cli, and validation queries plus rollback notes are provided.",
+      "files": [],
+      "expectations": [
+        "Flags the optionalFilter used for the EU region restriction as incorrect for a never-violate constraint and recommends a hard filter or secured filter instead",
+        "Handles the 'clearance' behavior with a scoped query Rule (with condition and governance such as owner/review or expiry) rather than a synonym",
+        "Accepts couch/sofa as genuine language equivalence but questions or qualifies sectional as not a true synonym",
+        "Distinguishes deterministic constraints, ranking preferences, and query-specific merchandising as separate lever classes",
+        "Routes live rule/synonym/settings writes to algolia-cli or algolia-mcp rather than applying them via this skill",
+        "Provides validation queries and/or rollback expectations for the changes"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "We want to add 'Price: low to high' and 'Newest first' sort options to our electronics search (index: electronics_main). A teammate says we should just sort the hits client-side in React since we already have the data. We also plan to A/B test a big ranking overhaul at the same time. Good plan?",
+      "expected_output": "The response rejects client-side sorting and recommends standard replicas for explicit sort-by (or virtual replicas where relevant sorting fits), documenting for each sort the displayed label, expected loss of relevance, and facet/filter consistency. It flags running the sort change and the ranking overhaul in the same A/B window as breaking causal attribution — change one meaningful relevance variable per experiment — and asks for/defines hypothesis, baseline, success metric, and rollback trigger before launch. Live replica creation is routed to algolia-cli.",
+      "files": [],
+      "expectations": [
+        "Rejects client-side sorting of Algolia hits and recommends replicas (standard and/or virtual) for the sort-by experiences",
+        "Treats each sort as a relevance decision: documents replica type, sort label, expected relevance tradeoff, or filter/facet consistency",
+        "Flags that A/B testing a ranking overhaul simultaneously with the sort change prevents causal attribution, and recommends one variable per experiment",
+        "Requires or drafts an experiment plan: hypothesis, baseline, success metric, decision rule, and rollback trigger",
+        "Routes live replica/settings creation to algolia-cli or algolia-mcp rather than performing it directly"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-index-configuration/references/configuration-guide.md
+++ b/skills/algolia-index-configuration/references/configuration-guide.md
@@ -1,0 +1,118 @@
+# Configuration Guide
+
+## Settings Change Workflow
+
+1. Export or record current settings.
+2. Identify the business reason for the change.
+3. Make the smallest coherent setting change.
+4. Test representative query sets before and after.
+5. Decide whether an A/B test is needed.
+6. Commit settings as code or document the dashboard change.
+
+## What Good Looks Like
+
+For any meaningful relevance change, produce:
+
+- The current settings snapshot or location of the backup.
+- The proposed settings diff.
+- 10 representative queries or category pages.
+- Expected top results for the most important queries.
+- Facets and filters that must still work after the change.
+- No-result or low-result behavior to verify.
+- A rollback step if the change hurts relevance.
+
+## Relevance Control Map
+
+Classify the desired behavior before choosing a setting. This prevents a preference from becoming an accidental hard constraint, or a campaign override from becoming permanent ranking logic.
+
+| Need | Primary control | Validate |
+| --- | --- | --- |
+| Must never return | Filters or secured filters | Restricted, region, availability, and permission scenarios never leak. |
+| Should appear earlier but can still return later | Optional filters or documented ranking preference | Preferred records rise without hiding acceptable alternatives. |
+| Should match first | Ordered searchable attributes and textual relevance settings | Exact, brand, title, and identifier query classes. |
+| Should break textual ties | Custom ranking | Business signals only decide between otherwise comparable results. |
+| Should change for a bounded intent or period | Rule or merchandising configuration | Condition, owner, expiry/review date, and affected queries. |
+| Needs an explicit customer sort | Standard or virtual replica where current docs support it | Sort label, tradeoff, filters, and facet behavior stay honest. |
+
+## Settings Decision Record
+
+For every material change, record the customer outcome, current evidence, selected setting and rejected alternatives, hard constraints versus optional preferences, expected wins and regressions, test queries, owner, rollback action, and experiment need.
+
+## Searchable Attributes
+
+- Include attributes users actually search: names, titles, descriptions, brands, categories, tags, identifiers.
+- Exclude display-only URLs, ranking-only metrics, internal flags, and noisy long fields unless the use case requires them.
+- Order attributes by importance. Attributes on the same priority level can be listed together.
+- Separate display title from searchable alternate titles when needed.
+
+### Exact And Typo-Sensitive Terms
+
+Do not weaken global typo behavior because a small set of identifiers needs exact treatment. Review current documented controls for SKU, part number, acronym, numeric token, postal code, and regulated-term exceptions. Test exact behavior alongside ordinary mobile typo recovery.
+
+## Custom Ranking
+
+- Use business metrics to break textual ties: popularity, sales, conversion rate, rating, freshness, availability, margin band, editorial priority.
+- Use numeric or boolean values.
+- Prefer meaningful buckets or rounded values when very precise values would prevent later ranking criteria from mattering.
+- Avoid using custom ranking to compensate for missing searchable attributes or bad record granularity.
+
+## Facets And Filters
+
+- Declare only fields that need filtering, faceting, or searchable facet values.
+- Normalize facet values before indexing.
+- Use facets for user-visible refinement and filters for hidden constraints as well as visible restrictions.
+- Test facet counts under common refinements.
+- Decide whether hierarchical facets are needed for category trees.
+
+### Filter Contract
+
+For each filterable attribute, state whether it is a hard constraint, visible refinement, silent product constraint, or optional preference. Only use optional filters for the last case. Do not use them for permissions, compliance, account entitlements, or any availability rule that must be deterministic.
+
+## Rules, Synonyms, And Merchandising
+
+- Use synonyms for query language equivalence, not for hiding catalog gaps.
+- Use rules for scoped overrides such as campaigns, redirects, pinned items, banners, or seasonal merchandising.
+- Name and scope rules so a future agent can tell why they exist.
+- Prefer rules with conditions over broad global overrides.
+- Include expiry or review notes for campaign-specific changes.
+
+### Choose The Right Asset
+
+| Situation | Use | Avoid |
+| --- | --- | --- |
+| Equivalent user language | Synonym | Using a synonym to mask missing records or a distinct concept. |
+| Typo-sensitive identifier | Current documented typo exception | Disabling typo tolerance globally. |
+| Query, filter, audience, or campaign-specific intent | Rule | A global pin or broad synonym. |
+| Prefer a category or brand without excluding alternatives | Optional filter where appropriate | A hard filter that removes relevant alternatives. |
+| Time-bound promotion, banner, redirect, pin, or hide | Rule with condition and review date | A permanent ranking change for temporary business intent. |
+
+Rules should have a human-readable name, owner, scope, review/expiry date, query examples, and rollback note.
+
+## Replicas And Sorting
+
+- Use replicas for alternate sort orders where the user explicitly chooses a sort.
+- Use virtual replicas when relevant sorting is appropriate and available for the use case.
+- Keep sort labels honest. If a sort significantly changes relevance, disclose or revisit the strategy.
+
+### Replica Preflight
+
+Before creating or recommending a replica, confirm the primary index, sort objective, replica type, settings inheritance, UI label, expected relevance tradeoff, and current product limitations. Test the same filters, facets, and record links on every sort surface.
+
+## Experiment And Rollback Discipline
+
+Use a controlled test for meaningful relevance changes when traffic and event coverage make it worthwhile:
+
+1. State one hypothesis and one isolated change.
+2. Define the control, variant, traffic split, duration/sample-size approach, success metric, and guardrail metric.
+3. Confirm click and conversion events can support interpretation.
+4. Wait for sufficient data and confidence before declaring a winner.
+5. Keep a rollback path: settings export, owner, trigger, and retest query set.
+
+Do not stop and restart a test as though it were continuous. Do not use an experiment to interpret a bundle of unrelated ranking, data, and UI changes.
+
+## Source Notes
+
+- Algolia relevance work starts with searchable attributes and custom ranking: https://www.algolia.com/doc/guides/managing-results/relevance-overview
+- Searchable attributes are all searchable by default until explicitly configured, and ordering affects ranking: https://www.algolia.com/doc/guides/managing-results/must-do/searchable-attributes
+- Custom ranking breaks ties with numeric or boolean business metrics: https://www.algolia.com/doc/guides/managing-results/must-do/custom-ranking
+- Facets let users refine results and are configured by declaring attributes for faceting: https://www.algolia.com/doc/guides/managing-results/refine-results/faceting

--- a/skills/algolia-instantsearch-ui/SKILL.md
+++ b/skills/algolia-instantsearch-ui/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: algolia-instantsearch-ui
+description: >
+  Build and review Algolia InstantSearch experiences in JavaScript, React, Vue, Angular (via InstantSearch.js; Angular InstantSearch is deprecated), or compatible frontend stacks. Use when planning or reviewing search results pages, browse/category pages, routing, widgets, filters, facets, sort-by, pagination, infinite hits, current refinements, insights middleware, SSR, or UI-state synchronization. For net-new search UI builds, start with algolia-discovery-planning, which loads algolia-search-implementation so data contract and event taxonomy decisions are visible before UI is marked ready. Do NOT use for autocomplete/typeahead experiences before the user commits to a results page; use algolia-autocomplete instead. Do NOT use for choosing between Algolia UI libraries; use algolia-ui-libraries. Do NOT use as the source of truth for current framework APIs or code-level implementation details; use the official instantsearch skill and current docs alongside this customer-readiness skill.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.4"
+---
+
+# Algolia InstantSearch UI
+
+Use this skill for full search or browse interfaces powered by InstantSearch. Keep the implementation faithful to the index contract and user journey.
+
+## Customer-Facing Standard
+
+- Treat a working search box as incomplete until filters, empty states, routing needs, mobile behavior, and events are considered.
+- Preserve the customer's existing design system and accessibility patterns.
+- Treat Algolia's official `instantsearch` skill from `algolia/skills` as the implementation authority for React InstantSearch, Vue InstantSearch, InstantSearch.js, source-of-truth checks, prop shapes, widgets, hooks, connectors, SSR, middleware, custom widgets, and framework anti-patterns.
+- Use this skill as the customer-readiness layer around the official skill: clarify the search journey, data contract, refinements, URL behavior, event attribution, mobile interaction, accessibility, and QA.
+- Use public `academy.algolia.com` for learning alignment and public `algolia.com/doc` for current implementation guidance when source-backed context is needed.
+- When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
+- Do not require custom Academy/docs access; use customer-provided sources only as optional context.
+- When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
+- Produce implementation notes or code plus a browser-verifiable QA checklist.
+
+## Official Companion Skills
+
+- Use official `instantsearch` from `https://github.com/algolia/skills` for production implementation details, source-of-truth checks, widget/hook/connector behavior, framework-specific anti-patterns, and code-level InstantSearch or Autocomplete work.
+- Use official `algolia-mcp` when live index schema, sample hits, facet values, or analytics should shape the UI.
+- Use this skill before the official `instantsearch` skill to frame the customer journey and after the official skill to validate UX, routing, event behavior, mobile behavior, and launch readiness.
+- Use `algolia-events-insights` alongside this skill when click/conversion attribution, Insights middleware, `queryID`, `objectID`, position, or `userToken` behavior affects the UI.
+
+## Source-Of-Truth Rules
+
+- Use the official `instantsearch` skill for framework-specific widgets, hooks, connectors, SSR, middleware, routing, and source-of-truth checks.
+- Follow the official skill's discovery pattern: identify the library (`react-instantsearch`, `vue-instantsearch`, or `instantsearch.js`), inspect existing setup, inspect installed types and docs before writing unfamiliar APIs, and read the matching official reference directory before implementation.
+- Inspect the project dependencies and installed types before assuming package names or prop shapes.
+- Verify current docs before writing SSR, routing, middleware, or event code that is not already present in the project.
+- For net-new implementations, avoid treating UI as isolated from data and events. Confirm that a data contract and event taxonomy exist, or create minimal versions and mark them provisional.
+
+## Workflow
+
+1. Read `references/instantsearch-guide.md` before implementing or reviewing UI code.
+2. Confirm the framework and InstantSearch package already used by the project. If code will be written, invoke the official `instantsearch` skill or follow its source-of-truth checks before choosing APIs.
+3. Confirm the data contract: index names, replicas, display attributes, facets, ranking fields, secured filters, and event attribution fields.
+4. Confirm the event taxonomy: result clicks, conversion path, `userToken`, `queryID`, `objectID`, index, and position handling.
+5. Define the result-page job: search results page, category/browse page, federated page, internal lookup, marketplace listing, or support/documentation search.
+6. Preserve existing design-system conventions and accessibility patterns.
+7. Teach the customer that Autocomplete helps users choose what to search for, while InstantSearch helps users explore, refine, recover, and act on results after the search.
+8. Wire routing, filters, sort, active refinement feedback, clear refinements, pagination/infinite hits, loading states, empty states, and events deliberately. A working search box alone is not a complete search experience.
+9. Verify the UI in a browser when possible, including empty states, slow/error states, mobile filter behavior, keyboard use, URL restoration, and event readiness.
+
+## Questions To Ask
+
+- Is this a search page, category browse page, federated experience, or internal tool?
+- Which index and replicas power each view?
+- Which refinements are user-visible versus applied silently?
+- Which filters are actually useful to the user for this record type, and are those attributes facetable in the index?
+- How will users see and clear active refinements?
+- Should URL routing preserve query and filters?
+- Should the first page load with an empty query, category filter, route-derived query, or user-entered query?
+- Is pagination, infinite loading, or "load more" the best continuation pattern for the context?
+- Is click/conversion attribution required for analytics or personalization?
+- What is the expected mobile filter/sort interaction?
+- Does this route need SSR, server components, static generation, or client-only rendering constraints?
+
+## Implementation Standards
+
+- Use InstantSearch widgets/hooks/connectors appropriate to the local framework.
+- When code is required, use the official `instantsearch` skill for the exact framework API and then apply this skill's readiness checks to the result.
+- Keep `searchClient`, index name, routing, and environment configuration out of hard-coded UI leaf components when the project has config patterns.
+- Use `configure` for query parameters and default filters that belong to the search state.
+- Include enough visible structure for users to understand, refine, recover, and continue: results, filters, active refinements, clear refinements, sort when needed, pagination or infinite loading, and empty/no-results recovery.
+- Make silent filters legible in the product design or documented in the implementation handoff. Users should not be confused by invisible constraints.
+- Match continuation pattern to intent: pagination for comparison and return-to-position, infinite hits for discovery, and load-more when users need both control and flow.
+- Treat mobile filters as a first-class interaction, not a compressed desktop sidebar.
+- Render accessible hit cards with stable objectID-aware interactions.
+- Enable Insights middleware or event helpers when events are in scope.
+- Do not mutate Algolia hits in ways that break objectID, queryID, position, or event attribution.
+- For SSR/routing work, verify hydration, URL state restoration, and back/forward behavior using the official skill's SSR and routing guidance.
+
+## Anti-Patterns
+
+- Treating a search input plus hits as a complete experience while ignoring filters, empty states, routing, mobile behavior, and events.
+- Re-implementing official InstantSearch API guidance from memory instead of using the official `instantsearch` skill and installed types.
+- Adding filters without active refinement feedback or a clear-all path.
+- Choosing facets because they exist in the data instead of because users need them to narrow results.
+- Showing facets with confusing labels, empty values, unstable ordering, or no count/range context.
+- Hard-coding index names, app IDs, or environment-specific values inside reusable UI leaf components.
+- Client-side sorting or filtering Algolia hits in ways that desynchronize facets, positions, pagination, or analytics.
+- Styling InstantSearch markup without checking generated class names or accessibility behavior.
+- Shipping a UI that cannot be verified in a browser with realistic records.
+- Shipping desktop-only filter behavior and assuming mobile users can recover.
+- Enabling URL routing without validating reload, sharing, and back/forward behavior.
+
+## Completion Checkpoints
+
+Before calling the UI ready, or when handing off a prototype with follow-ups, state whether these checkpoints are satisfied, deferred, or unknown:
+
+- Referenced data contract or explicit minimal demo data contract.
+- Referenced event taxonomy or explicit user-approved event deferral.
+- Official `instantsearch` skill or current docs/types used for framework-specific API choices.
+- Hit components preserve `objectID`, `index`, `queryID`, position, and `userToken` for event wiring.
+- Facets and filters exist in the index contract.
+- Browser QA covers query, filters, active refinements, clear refinements, sort, pagination or infinite loading, empty states, loading/error states, routing when enabled, mobile behavior, keyboard behavior, and event readiness.
+
+## Academy And Customer Education Alignment
+
+When source-backed guidance is needed, search public Academy sources for UI learning objectives and public Algolia docs for InstantSearch, routing, widgets, filters, facets, UI state, SSR, and event attribution. Use source guidance to choose maturity level, use-case bundle, guided prompts, and QA artifacts. Keep the skill procedural and source-aligned rather than embedding stale API documentation.
+
+## Maturity Behavior
+
+- Beginner implementation: build the smallest complete search or browse experience with query, hits, filters, loading, empty state, and clear index configuration.
+- Production readiness: validate routing, mobile filters, accessibility, API-key boundaries, event attribution, error states, and environment configuration.
+- Optimization: review query analytics, facet usage, performance, UI friction, A/B testing, and relevance handoff to index configuration.
+- AI readiness: confirm the UI preserves user context, objectID, index, queryID, position, and conversion paths needed by AI and personalization features.
+
+## Output Contract
+
+Return implemented code or a review with file references, plus an Official Skill Usage Note, Customer UI Plan, Data/Event Readiness Notes, and concise QA checklist covering query, filters, active refinements, sort, pagination/infinite loading, empty states, routing, mobile behavior, accessibility, and events.

--- a/skills/algolia-instantsearch-ui/agents/openai.yaml
+++ b/skills/algolia-instantsearch-ui/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia InstantSearch UI"
+  short_description: "Build InstantSearch search experiences"
+  default_prompt: "Use $algolia-instantsearch-ui to build or review an Algolia InstantSearch search results UI."

--- a/skills/algolia-instantsearch-ui/evals/evals.json
+++ b/skills/algolia-instantsearch-ui/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "algolia-instantsearch-ui",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Building a search results page for our pet supplies store. React 18 app, we already have react-instantsearch installed and an index called pets_products with facets on brand, animal_type, and price_range. I got a SearchBox and Hits rendering - what else do I actually need before this is 'done'? Marketing also wants shareable URLs for filtered searches.",
+      "expected_output": "The response treats a working search box plus hits as incomplete: it walks through filters/refinement lists for the declared facets, active refinement display and clear-all, sort if needed, pagination or infinite hits with rationale, empty/no-results recovery, loading and error states, URL routing for the shareable-links requirement (with reload/back-forward validation), and mobile filter behavior. It confirms the data contract and event taxonomy exist (or marks them provisional), defers exact framework API details to the official instantsearch skill and installed types, and ends with a browser-verifiable QA checklist.",
+      "files": [],
+      "expectations": [
+        "States that a search box plus hits is not a complete experience and enumerates the missing surfaces: filters, active refinements with a clear path, pagination or infinite loading, empty states, loading/error states",
+        "Addresses the shareable-URL requirement with InstantSearch routing and calls out validating reload, sharing, and back/forward behavior",
+        "Confirms or asks whether a data contract and event taxonomy exist, or creates minimal provisional versions rather than ignoring data and events",
+        "Defers framework-specific API/prop details to the official instantsearch skill, current docs, or installed types instead of asserting APIs from memory",
+        "Covers mobile filter behavior as a first-class interaction, not an afterthought",
+        "Ends with a QA checklist covering query, filters, refinements, pagination, empty states, routing, mobile, and event readiness"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Code review request: our Vue 3 storefront category pages use vue-instantsearch, but a dev sorted the hits array client-side by price before rendering, hardcoded the index name 'shop_live' inside the HitCard component, and strips hits down to just {title, image, url} before passing them to the card. Ship it?",
+      "expected_output": "The review flags all three issues per the skill's anti-patterns and standards: client-side sorting desynchronizes facets, positions, pagination, and analytics (recommend a replica/sort widget instead); hardcoding index names inside reusable leaf components violates configuration standards; and stripping hits destroys objectID/queryID/position needed for event attribution — hit mutation must not break attribution fields. It does not approve shipping as-is, references the official instantsearch skill for the framework-correct fix, and requests browser QA before ready.",
+      "files": [],
+      "expectations": [
+        "Flags client-side sorting of Algolia hits as an anti-pattern that desynchronizes facets, positions, pagination, or analytics, and points to sort-by replicas or proper widgets instead",
+        "Flags the hardcoded index name inside the HitCard leaf component and recommends moving it to configuration",
+        "Flags that stripping hits to {title, image, url} breaks objectID/queryID/position preservation needed for event attribution",
+        "Does not approve shipping as-is; states what must change before the UI is ready",
+        "References the official instantsearch skill or current docs for the framework-specific corrections rather than inventing Vue InstantSearch APIs",
+        "Mentions browser verification or a QA checklist as part of completion"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "We need SSR for our Next.js 14 app router search page (index: articles_prod) for SEO. Never done InstantSearch SSR before. Also PM asked: do we even need the events/insights stuff for v1, can we skip it?",
+      "expected_output": "The response does not write SSR code from memory: it follows the source-of-truth rules, invoking the official instantsearch skill and verifying current docs for SSR/hydration/routing patterns in Next.js app router before choosing APIs, and includes hydration, URL state restoration, and back/forward behavior in QA. On skipping events, it does not silently drop them: it explains the cost (analytics, personalization, AI readiness), and if deferred, records an explicit user-approved deferral with follow-up rather than just saying yes.",
+      "files": [],
+      "expectations": [
+        "Defers SSR implementation details to the official instantsearch skill and current docs instead of writing Next.js SSR/hydration code purely from memory",
+        "Includes hydration, URL state restoration, and back/forward behavior in the QA or validation plan",
+        "Does not simply agree to skip events; explains what event deferral costs (attribution, analytics, personalization/AI readiness)",
+        "If events are deferred, records it as an explicit user-approved deferral with a follow-up, per the completion checkpoints",
+        "Checks or asks about the data contract (display attributes, facets) for articles_prod before treating the UI as specifiable"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-instantsearch-ui/references/instantsearch-guide.md
+++ b/skills/algolia-instantsearch-ui/references/instantsearch-guide.md
@@ -1,0 +1,234 @@
+# InstantSearch Guide
+
+## Official Skill Bridge
+
+Algolia already maintains an official `instantsearch` skill in `algolia/skills`. Use it as the implementation authority whenever code, framework APIs, widget props, hooks, connectors, SSR, middleware, routing APIs, autocomplete integration, or source-of-truth checks are involved.
+
+This skill owns the customer-readiness layer around that official skill:
+
+| Concern | Use official `instantsearch` for | Use this skill for |
+| --- | --- | --- |
+| Framework/API | Current React InstantSearch, Vue InstantSearch, and InstantSearch.js APIs | Whether the chosen UI pattern fits the customer journey |
+| Source of truth | Installed types, live docs, CSS class names, widget props, SSR/middleware details | Readiness checks, business explanation, UX QA, and launch handoff |
+| Search results page | React search results page features, styling, anti-patterns, custom widgets | Facet usefulness, mobile filters, empty states, routing expectations, event readiness |
+| Autocomplete | Official autocomplete pattern references | Whether autocomplete should hand off to a results page or stay separate |
+| Events | Event helper and middleware mechanics | Whether hit components preserve `queryID`, `objectID`, index, position, and `userToken` for the customer's analytics goals |
+
+Recommended sequence:
+
+1. Use this guide to frame the search experience, user journey, data contract, and event requirements.
+2. Use official `instantsearch` for implementation-specific API decisions.
+3. Return to this guide for customer-facing QA, mobile behavior, event-readiness, and launch notes.
+
+## Implementation Map
+
+Before coding, identify:
+
+- Package: `react-instantsearch`, `vue-instantsearch`, `instantsearch.js`, or another integration. Angular InstantSearch is deprecated; for Angular projects use `instantsearch.js` directly and treat existing `angular-instantsearch` code as migration work. The official skill currently centers React, Vue, and InstantSearch.js.
+- Index and replicas used by the page.
+- Query source: search box, route param, category page, static filter, or autocomplete handoff.
+- Refinements: user-visible widgets and silent filters.
+- Routing requirements.
+- Event requirements.
+- Empty/loading/error states.
+- Server-side rendering requirements.
+- Mobile filter and sort pattern.
+- Detail-page navigation and return-to-results behavior.
+- Whether the page is public, authenticated, B2B permissioned, or internal.
+
+## Customer Journey Frames
+
+Use one of these frames before choosing widgets:
+
+| Frame | User intent | UI emphasis | Common risks |
+| --- | --- | --- | --- |
+| Search results page | User has a query and wants the best matches | Search box, hits, stats, filters, sort when useful, pagination or infinite hits | Query state not preserved, filters feel arbitrary, no recovery path |
+| Browse/category page | User starts from a category, collection, or merchandising context | Silent category filter, visible refinements, current category context, sort, product/content cards | Invisible filters confuse users, category route and UI state drift |
+| Marketplace or catalog | User compares many entities with constraints | Dense cards or rows, strong filters, active refinements, saved/shareable state | Client-side filtering breaks counts, permissions or seller filters are hidden |
+| Support or docs search | User wants an answer quickly | Query clarity, content type filters, snippets, empty-state suggestions, feedback path | Facets distract from answer-finding, no no-results recovery |
+| Internal lookup | User needs speed and precision | Compact layout, keyboard flow, exact filters, persistent state | Marketing-style layouts reduce scan speed |
+
+For each frame, answer:
+
+- What tells the user where they are?
+- What tells them why results changed?
+- How do they recover from a bad query or too many filters?
+- What action do they take after finding a result?
+- Which event proves the UI helped?
+
+## Academy Mental Model
+
+Use this distinction when guiding customers:
+
+- Autocomplete helps users decide what to search for before they commit.
+- InstantSearch helps users explore, refine, recover, and act on the results after they search.
+- Algolia Search returns matching records.
+- InstantSearch widgets turn records, refinements, routing, and events into a usable search results experience.
+
+A useful results page should answer:
+
+- What am I seeing?
+- How can I narrow this?
+- What is currently selected?
+- How do I recover if the results are wrong?
+- What action can I take next?
+
+## Data Contract Checks
+
+Before implementation or review, confirm the UI has what it needs from the index:
+
+| UI need | Data/index requirement | Failure mode |
+| --- | --- | --- |
+| Result title, image, URL, and summary | Display attributes exist and are consistently populated | Hit cards look empty, inconsistent, or untrustworthy |
+| Filters/facets | Attributes are configured for faceting and have useful value distributions | Filter widgets are empty, noisy, or misleading |
+| Range filters | Numeric values are normalized and facetable/range-ready | Sliders/ranges are inaccurate or absent |
+| Sort options | Replicas or supported sorting strategy exists | Sort control appears but does not match Algolia ranking behavior |
+| Category/browse pages | Category or collection filters are stable and route-compatible | Route says one thing while results show another |
+| Event attribution | Hits preserve `objectID`, `index`, `queryID`, and position | Insights events arrive but cannot be attributed |
+| Permissions/B2B | Secured filters or permission attributes are designed outside UI-only filtering | Users see forbidden records or counts leak inaccessible data |
+
+## Widget And Connector Guidance
+
+- Use built-in widgets/hooks first for standard search box, hits, refinement lists, menu, range, sort-by, pagination, infinite hits, current refinements, and stats.
+- Customize rendering when project UI requires it, while preserving widget semantics.
+- Use connectors or hooks for custom UI that still needs InstantSearch state.
+- Create a custom widget only when existing widgets/connectors cannot express the behavior.
+
+Core teaching pattern:
+
+- `searchBox` lets users express a query.
+- `hits` shows the matching records.
+- `refinementList`, `menu`, `range`, and related widgets let users narrow results.
+- `currentRefinements` shows what is active.
+- `clearRefinements` gives users a recovery path.
+- `pagination` or `infiniteHits` lets users continue.
+- `configure` applies search parameters that belong to the search state.
+
+Decision rules:
+
+- Use a widget when the built-in behavior matches the desired interaction.
+- Use hooks or connectors when the UI must be custom but should still preserve InstantSearch state.
+- Use a custom widget only when the behavior is stateful and not expressible with existing widgets, hooks, or connectors.
+- Use index settings, replicas, or rules for relevance and sorting behavior that should be true for all users, rather than hiding it in component code.
+- Use `configure` for search parameters that are part of the InstantSearch state, such as default filters or hits-per-page. Do not use it as a dumping ground for unrelated UI behavior.
+
+## Filters And Refinements
+
+Good filters are not merely available attributes. They match how users narrow decisions.
+
+Checklist:
+
+- Each visible facet has a user reason to exist.
+- Facet labels are customer-facing, not raw field names.
+- Active refinements are visible.
+- Users can clear one refinement or all refinements.
+- Counts, ranges, and disabled states make sense with the current query.
+- Silent filters are documented and visible in the page context when they shape user expectations.
+- Mobile filters open, close, apply, clear, and preserve scroll position predictably.
+
+Common filter choices:
+
+| Pattern | Use when | Watch for |
+| --- | --- | --- |
+| Refinement list | Users choose one or many values | Long lists need search, ordering, or show-more behavior |
+| Menu | User chooses one category-like value | Multi-select expectations can make menus frustrating |
+| Range | Numeric comparison matters | Values must be normalized and meaningful |
+| Toggle | A binary refinement is high value | Hidden defaults can surprise users |
+| Sort-by | Users need alternate orderings | Sort replicas and ranking tradeoffs must be understood |
+
+## Routing
+
+- Enable routing when users should share or revisit query/refinement state.
+- Do not combine `initialUiState` and routing for the same state; the official docs state the two options override each other.
+- Keep route parameter names human-readable for public pages where possible.
+- Verify browser back/forward behavior and page reload restoration.
+- Decide whether category context comes from the route, a silent filter, or both.
+- Validate that autocomplete handoff creates the intended search results URL.
+- For authenticated or permissioned pages, avoid putting sensitive filters or identifiers in public URLs.
+
+Routing QA:
+
+- Search, refine, sort, and paginate, then reload the page.
+- Copy the URL into a new tab.
+- Use browser back and forward after several refinements.
+- Clear refinements and confirm the URL returns to an understandable base state.
+- Navigate to a hit detail page and return without losing the user's place when the product experience requires it.
+
+## Events
+
+- Enable click analytics for result interactions that require queryID.
+- Use InstantSearch event helpers or middleware where appropriate.
+- Make hit components receive the original hit data needed for objectID, index, position, and queryID.
+- Test click and conversion flows from search, category, and sorted/replica views.
+- For custom hit components, preserve the original hit object or explicitly pass the fields required by Insights.
+- Treat event wiring as part of UI completeness when analytics, personalization, Dynamic Re-Ranking, Recommend, NeuralSearch evaluation, or Agent Studio feedback are in scope.
+- Coordinate with `algolia-events-insights` for the event taxonomy and validation standard.
+
+Event-readiness questions:
+
+- Does the search response include `queryID` for clickable results?
+- Does the rendered hit know its displayed one-based position?
+- Does the click event reference the exact `objectID` returned by Algolia?
+- Does sort/replica selection change the index used by the event?
+- Does mobile UI fire the same event as desktop?
+- Are clicks, add-to-cart, purchase, save, lead, or support-resolution events owned by frontend, backend, or a connector?
+
+## SSR And Performance
+
+Use official `instantsearch` for SSR implementation details. This skill only adds readiness checks:
+
+- SSR/hydration should not double-query unexpectedly.
+- Initial UI state, routing, and server-rendered state should not fight each other.
+- Loading and stalled-search states should be designed, not accidental.
+- Search credentials must remain search-only on the client.
+- Large result cards, images, and filter panels should not make search feel slow.
+- For Next.js, Remix, Nuxt, or equivalent frameworks, validate route transitions, hydration warnings, and client navigation.
+
+## Mobile And Accessibility
+
+Mobile search is not a smaller desktop sidebar.
+
+- Filters and sort need an obvious entry point.
+- Users need to see active filter count before reopening the panel.
+- Apply, clear, and close actions should be reachable.
+- Result cards should remain scannable with images, prices, snippets, or metadata appropriate to the use case.
+- Keyboard focus should not get trapped in filter drawers.
+- Search input labels, result links, refinement controls, and clear buttons need accessible names.
+- Live-updated result counts and empty states should be understandable to assistive technology users.
+
+## UX QA
+
+- Query typing and clearing.
+- Filter selection, deselection, and current refinements.
+- Clear all and clear-one recovery.
+- Sort switching and replica correctness.
+- Pagination or infinite loading.
+- Empty state and no-query state.
+- Slow network and error behavior.
+- Mobile filter/sort affordances.
+- Accessibility for form labels, result links, keyboard focus, and live-updated content.
+- Users can tell why results changed after selecting filters.
+- Users can recover from too many filters without starting over.
+- Mobile filters do not crowd or hide the results.
+- URL sharing, reload, and back/forward behavior when routing is enabled.
+- Result click and conversion event readiness when events are in scope.
+- Detail-page navigation and return-to-results behavior.
+
+## Review Output Template
+
+Use this structure for audits or handoffs:
+
+1. Official Skill Usage Note: which official `instantsearch` guidance, installed types, docs, or references were used.
+2. Customer UI Plan: page frame, query source, widgets/refinements, routing, mobile behavior, and continuation pattern.
+3. Data/Event Readiness Notes: index, replicas, facets, display attributes, secured filters, event fields, and known gaps.
+4. Implementation Notes: files changed or proposed, framework package, configuration boundaries, and any deferred API checks.
+5. QA Checklist: browser tests for query, filters, active refinements, clear refinements, sort, pagination/infinite hits, empty/loading/error states, routing, mobile, accessibility, and event readiness.
+
+## Source Notes
+
+- Official Algolia skills repository: https://github.com/algolia/skills
+- Official `instantsearch` skill includes React InstantSearch, Vue InstantSearch, InstantSearch.js, source-of-truth checks, React search results pages, autocomplete references, middleware, SSR, and custom widget guidance: https://github.com/algolia/skills/tree/main/skills/instantsearch
+- InstantSearch is a frontend UI library that combines widgets to build search interfaces: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js
+- InstantSearch supports predefined widgets, customized widgets, and custom widgets/connectors: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js
+- Routing lets InstantSearch synchronize UI state with the browser URL: https://www.algolia.com/doc/guides/building-search-ui/going-further/routing-urls/js
+- InstantSearch event implementation guidance: https://www.algolia.com/doc/guides/building-search-ui/events/js

--- a/skills/algolia-neuralsearch/SKILL.md
+++ b/skills/algolia-neuralsearch/SKILL.md
@@ -20,7 +20,7 @@ Use this skill when adding or optimizing NeuralSearch. Neural relevance depends 
 - When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
 - Do not require custom Academy/docs access; use customer-provided sources only as optional context.
 - When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
-- Produce a clear go, limited pilot, fix-first, or do-not-start recommendation.
+- Produce a clear go, limited rollout, fix-first, or do-not-start recommendation.
 
 ## Official Companion Skills
 

--- a/skills/algolia-neuralsearch/SKILL.md
+++ b/skills/algolia-neuralsearch/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: algolia-neuralsearch
+description: >
+  Product-specific Algolia NeuralSearch implementation, validation, and optimization guidance. Use when planning, enabling, configuring, testing, or tuning NeuralSearch, AI relevance, semantic retrieval, adaptive intent, model training, A/B testing, limitations review, query analysis, relevance diagnostics, event readiness, and data preparation for neural or hybrid search experiences. Do NOT use for generic vector database, embeddings, or non-Algolia semantic search architecture. Do NOT use for live settings changes, replica creation, or analytics retrieval; use algolia-cli or algolia-mcp first, then this skill for readiness and rollout guidance.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.4"
+---
+
+# Algolia NeuralSearch
+
+Use this skill when adding or optimizing NeuralSearch. Neural relevance depends on good records, explicit relevance intent, representative queries, and measurement signals; do not treat it as a switch that fixes poor data. Current public docs state that click and conversion events are not required to activate NeuralSearch, but when present they guide semantic attribute selection and unlock retraining and Adaptive Intent; recheck them before advising on activation.
+
+## Customer-Facing Standard
+
+- Treat NeuralSearch as a rollout decision, not a standalone toggle.
+- Require evidence for data readiness, event readiness, query evaluation, filters, permissions, and rollback.
+- Use public `academy.algolia.com` for learning alignment and public `algolia.com/doc` for current implementation guidance when source-backed context is needed.
+- When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
+- Do not require custom Academy/docs access; use customer-provided sources only as optional context.
+- When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
+- Produce a clear go, limited pilot, fix-first, or do-not-start recommendation.
+
+## Official Companion Skills
+
+- Use official `algolia-mcp` for live query behavior, top searches, no-result searches, click/no-click signals, recommendations, and analytics evidence.
+- Use official `algolia-cli` when settings, replicas, rules, synonyms, or index changes are required.
+- Use this skill after the official tool call to produce rollout readiness, semantic query sets, measurement plans, and customer-facing launch guidance.
+
+## Source-Of-Truth Rules
+
+- Verify current NeuralSearch docs before stating activation steps, limitations, model training behavior, Adaptive Intent requirements, A/B testing behavior, or replica/sort constraints.
+- Current public docs state that click and conversion events are not activation prerequisites: without events NeuralSearch selects semantic attributes from record structure, and with events it selects and weights attributes from real behavior. Adaptive Intent and retraining do depend on engagement data. Recheck the chosen mode's current docs before advising on cold-start, preview, activation, model training, or Adaptive Intent behavior.
+- Do not recommend launch without a representative query set and a rollback or staged rollout plan.
+
+## Workflow
+
+1. Read `references/neuralsearch-guide.md` before implementation or review.
+2. Read `references/example-output.md` when producing a readiness report or rollout plan.
+3. Use `$algolia-discovery-planning` to clarify the search journey, success metrics, and query patterns.
+4. Use `$algolia-data-modeling` to ensure semantic fields, titles, descriptions, categories, and attributes are search-ready.
+5. Use `$algolia-index-configuration` to preserve the right balance of textual relevance, filters, facets, custom ranking, replicas, and business rules.
+6. Use `$algolia-events-insights` and `$algolia-release-qa` for event readiness, A/B testing, analytics, and launch validation.
+7. Teach the rollout path: confirm eligibility and readiness, preview with a representative query set, test with a replica or controlled configuration, compare against baseline, tune one semantic variable at a time, then monitor and optimize.
+
+## Questions To Ask
+
+- Which query classes should NeuralSearch improve: vague, conceptual, natural-language, synonym-heavy, long-tail, support/content, or product discovery queries?
+- Which queries must remain exact, deterministic, compliance-sensitive, or heavily merchandised?
+- Which record fields carry semantic meaning, and which are noisy or internal?
+- Is the customer's plan and application eligible for the NeuralSearch mode they want to use?
+- Will testing happen in a replica, an A/B test, a staged rollout, or a manual evaluation environment?
+- Which semantic behavior should be conservative, broader reach, or append-only relative to keyword relevance?
+- Are click, conversion, view, add-to-cart, purchase, or feedback events available to evaluate relevance?
+- What is the baseline: current conversion, CTR, zero-result rate, no-click searches, top-query relevance, or manual judgment set?
+- Is A/B testing available before broad rollout?
+- Which limitations, language/locale constraints, filters, and sort expectations need to be reviewed in current docs?
+- Which attributes should carry semantic meaning, in priority order, and which attributes must never influence semantic matching?
+- For a surprising result, which evidence will distinguish a data problem, semantic-setting choice, keyword behavior, or merchandising override?
+
+## Implementation Standards
+
+- Audit records before enabling neural relevance. Titles, descriptions, categories, brand, attributes, and content summaries should reflect how users search.
+- Keep filters, facets, secured data, and business rules explicit; semantic matching must not leak inaccessible or irrelevant records.
+- Build a query evaluation set that includes head, tail, exact, vague, natural-language, branded, typo, category, and no-result queries.
+- Use A/B testing or a staged rollout for meaningful relevance changes.
+- Do not optimize only by subjective spot checks. Pair human review with analytics and event signals.
+- Document limitations and feature constraints from current Algolia docs before promising behavior.
+- Use explainability tools or result inspection to diagnose surprising results before changing many settings.
+- Treat merchandising rules as compatible with NeuralSearch, but test pinned, buried, suppressed, promoted, and campaign-driven results against semantic behavior.
+- Use analytics tags, replica comparisons, or A/B test segmentation so NeuralSearch impact can be isolated from unrelated relevance changes.
+- Select a small, meaningful semantic attribute set and justify the priority of each field; do not let IDs, supplier boilerplate, internal notes, or duplicated text dilute semantic meaning.
+- Compare hybrid behavior by result origin where current diagnostics expose it: keyword match, semantic match, or both. Use this evidence to diagnose rather than guessing from a result list.
+- Change one meaningful variable per evaluation round: semantic fields or priority, blend behavior, business rule, or ranking context. Keep the before/after query set and decision record together.
+
+## Anti-Patterns
+
+- Treating NeuralSearch as a fix for poor record content, missing filters, weak relevance settings, or unclear business rules.
+- Evaluating only aggregate conversion or a handful of favorable queries.
+- Ignoring exact-match, compliance, permissions, merchandising, or sorted-result regressions.
+- Claiming events are required to activate NeuralSearch, or skipping event readiness entirely because activation does not require events; events still gate Adaptive Intent, retraining, and trustworthy measurement.
+- Promising Adaptive Intent or model-training behavior without checking current docs and event readiness.
+- Treating semantic configuration as a one-time activation choice instead of a testable, reversible relevance decision.
+- Diagnosing a surprising result by changing multiple fields, ranking rules, and merchandising settings at once.
+
+## Academy And Customer Education Alignment
+
+When source-backed guidance is needed, search public Academy sources for NeuralSearch and AI-readiness learning objectives and public Algolia docs for semantic retrieval, data readiness, events-informed optimization, A/B testing, limitations, and current rollout guidance. Map the request to maturity level and use case, then produce guided prompts such as "Use this skill to design my NeuralSearch rollout" or "Use this skill to validate my data, measurement path, and query set before rolling out NeuralSearch."
+
+## Maturity Behavior
+
+- Beginner implementation: do not start with NeuralSearch if basic data, filters, and search UI are not yet stable.
+- Production readiness: require deterministic filters, secured data strategy, rollback plan, and query evaluation set.
+- Optimization: compare semantic relevance against baseline relevance with representative query classes and outcome metrics.
+- AI readiness: prefer reliable events and feedback loops for measurement and Adaptive Intent readiness, while requiring permission-aware records and a clear go/fix-first/do-not-start recommendation.
+
+## Output Contract
+
+Return a NeuralSearch readiness assessment, semantic attribute rationale, query test set, measurement plan, rollout strategy, explainability/diagnostic plan, and validation report. Call out missing data, missing or weak events, noisy fields, unsupported feature constraints, or business-rule conflicts before recommending launch.

--- a/skills/algolia-neuralsearch/agents/openai.yaml
+++ b/skills/algolia-neuralsearch/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia NeuralSearch"
+  short_description: "Implement and optimize NeuralSearch"
+  default_prompt: "Use $algolia-neuralsearch to plan, implement, validate, and optimize Algolia NeuralSearch."

--- a/skills/algolia-neuralsearch/evals/evals.json
+++ b/skills/algolia-neuralsearch/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "algolia-neuralsearch",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Our search results are pretty bad - lots of zero-result queries and users complain they can't find things. Records in our home_decor_live index are thin (title + SKU + price, descriptions mostly empty). Boss saw a NeuralSearch demo and wants it switched on this sprint to fix everything. Can we?",
+      "expected_output": "The response does not treat NeuralSearch as a switch that fixes poor data: with thin records (empty descriptions, little semantic content) it issues a fix-first recommendation, explaining neural relevance depends on records that carry semantic meaning. It requires evidence for readiness (data audit, representative query set including the zero-result queries, baseline metrics, rollback plan), correctly notes per current docs that click/conversion events are not required for activation but guide semantic attribute selection and gate Adaptive Intent/retraining, marks doc-dependent behavior for live verification, and routes any live settings/analytics work to algolia-cli or algolia-mcp.",
+      "files": [],
+      "expectations": [
+        "Does not recommend enabling NeuralSearch as-is; treats it as a rollout decision and issues a fix-first (or do-not-start) recommendation given the thin records",
+        "States that NeuralSearch cannot compensate for records lacking semantic content, and recommends enriching titles/descriptions/categories first",
+        "Correctly states that events are not required to activate NeuralSearch but do gate Adaptive Intent, retraining, and trustworthy measurement — without claiming events are an activation prerequisite",
+        "Requires a representative query evaluation set (including the zero-result and vague queries) and a baseline before any rollout",
+        "Recommends verifying current NeuralSearch docs (eligibility, limitations, activation behavior) rather than asserting product behavior from memory",
+        "Routes live analytics inspection or settings changes to algolia-mcp or algolia-cli"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "We're ready to actually roll out NeuralSearch on our outdoor equipment index (records are rich, events healthy for 6+ months). How do we test it safely? Also after an internal preview, one weird thing: searching 'bear canister' now surfaces a teddy bear product #4. Marketing wants us to just pin the right products and ship.",
+      "expected_output": "The response teaches the rollout path: confirm eligibility/readiness, preview with a representative query set spanning query classes (head, tail, exact, vague, natural-language, branded, typo, no-result), test via replica or A/B against baseline, tune one semantic variable per round, then monitor. For the teddy bear result, it diagnoses before patching: use explainability/result-origin inspection to distinguish a data problem, semantic-setting choice, keyword behavior, or merchandising override, rather than pinning results to mask it — and warns against changing multiple settings at once. It includes a rollback/staged rollout plan and measurement plan, routing live replica/A-B operations to algolia-cli/algolia-mcp.",
+      "files": [],
+      "expectations": [
+        "Lays out the staged rollout path: readiness confirmation, preview with a representative query set, replica or A/B comparison against a baseline, then monitored rollout",
+        "Builds or requests a query evaluation set covering multiple query classes (exact, vague, natural-language, branded, typo, no-result), not just favorable queries",
+        "Diagnoses the 'bear canister' anomaly with explainability or result-origin inspection (keyword vs semantic match) before recommending fixes, instead of immediately pinning results",
+        "Warns against changing multiple semantic/ranking/merchandising variables at once; one meaningful variable per evaluation round with a before/after record",
+        "Includes a rollback trigger or staged rollout plan and does not recommend launch without one",
+        "Routes live replica creation, A/B setup, or analytics retrieval to algolia-cli or algolia-mcp"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Picking semantic attributes for NeuralSearch on our industrial parts index (mfg_parts_prod). Attributes include: part_name, long_description, internal_notes, supplier_boilerplate (same 2 paragraphs on 8k records), part_number, compliance_class, warehouse_location. Which should carry semantic meaning? Also some parts are restricted by customer contract - sales says semantic search 'might loosen that up', which sounds concerning.",
+      "expected_output": "The response selects a small, meaningful semantic attribute set with justified priority (part_name, long_description; possibly compliance_class as a facet not semantic), and excludes noise: internal_notes, duplicated supplier_boilerplate, part_number (exact/deterministic), warehouse_location. It firmly corrects the sales expectation: filters, secured data, and permissions must remain explicit and deterministic — semantic matching must never leak restricted records — and contract restrictions stay as secured filters. It flags exact-match query classes (part numbers) as needing to remain deterministic and verifies limitations against current docs.",
+      "files": [],
+      "expectations": [
+        "Selects a small prioritized semantic attribute set and justifies each field's priority rather than including everything",
+        "Excludes IDs, internal notes, duplicated supplier boilerplate, and operational fields (warehouse_location) from semantic meaning as noise",
+        "States that contract/permission restrictions must remain deterministic (secured filters or equivalent) and that semantic matching must not loosen or leak restricted records",
+        "Identifies part-number/exact queries as a class that must remain exact and deterministic under neural/hybrid behavior",
+        "Recommends verifying current docs for limitations and semantic configuration behavior before promising results"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-neuralsearch/references/example-output.md
+++ b/skills/algolia-neuralsearch/references/example-output.md
@@ -1,0 +1,64 @@
+# Example Output: NeuralSearch Readiness Report
+
+Use this shape before recommending rollout.
+
+## Recommendation
+
+Status: fix first.
+
+NeuralSearch is promising for long-tail and natural-language product queries, but the rollout should wait until the team validates semantic fields, removes noisy record text, and confirms event quality for measurement.
+
+## Readiness Gates
+
+| Gate | Status | Evidence | Required action |
+| --- | --- | --- | --- |
+| Semantic record fields | Needs work | Product titles and descriptions exist, but some records contain supplier boilerplate and duplicated category text. | Clean noisy fields or exclude them from semantic relevance inputs where appropriate. |
+| Filters and permissions | Ready | Region and availability filters are present and tested. | Keep these deterministic during NeuralSearch testing. |
+| Representative query set | Needs work | Top exact-match queries exist, but vague and natural-language examples are missing. | Build a 30-query evaluation set across exact, vague, synonym-heavy, and long-tail queries. |
+| Events and measurement | Needs work | Click events exist, but conversion attribution is incomplete. | Treat as a measurement and optimization risk; fix conversion events before relying on outcome metrics or Adaptive Intent. |
+| Rollback path | Ready | Settings can be restored from exported configuration. | Keep rollback notes with the experiment plan. |
+
+## Query Evaluation Set
+
+| Query class | Example | Expected behavior |
+| --- | --- | --- |
+| Exact product | `trail runner 2` | Exact product appears first. |
+| Natural language | `shoes for muddy half marathon training` | Waterproof trail running shoes rank above casual shoes. |
+| Attribute-heavy | `blue womens size 9 trail shoes` | Results respect color, gender, size, and trail intent. |
+| Compliance-sensitive | `kids allergy safe snack` | Safety and category constraints remain deterministic. |
+| Merchandised | `holiday gift set` | Rules and campaigns still behave as intended. |
+
+## Semantic Attribute Rationale
+
+| Attribute | Priority | Why it carries meaning | Risk or follow-up |
+| --- | --- | --- | --- |
+| `name` | High | Uses the shopper's product language. | Check opaque variant codes and duplicate names. |
+| `description` | Medium | Explains use case, material, and activity context. | Remove repeated supplier boilerplate. |
+| `categories` | Medium | Gives a stable shopper-facing classification. | Keep permissions and availability as deterministic filters. |
+
+## Hybrid Evidence Log
+
+| Query | Observation | Evidence to inspect | Next action |
+| --- | --- | --- | --- |
+| `shoes for muddy half marathon training` | A waterproof trail shoe improved from page two to the top group. | Compare keyword/semantic evidence and the result's description. | Keep as a candidate win; validate with traffic. |
+| `trail runner 2` | Exact product must remain first. | Check exact keyword behavior, pins, and custom ranking before semantic fields. | Block rollout if the deterministic result regresses. |
+
+## Rollout Plan
+
+1. Clean semantic fields and confirm record examples.
+2. Fix primary conversion events before relying on outcome metrics or Adaptive Intent.
+3. Build the evaluation query set.
+4. Run a controlled test against current relevance.
+5. Review wins, regressions, and unexplainable results.
+6. Launch gradually with rollback notes.
+
+## Diagnostics And Optimization
+
+| Area | What to inspect | Why it matters |
+| --- | --- | --- |
+| Semantic fields | Titles, descriptions, categories, attributes, summaries, and noisy/internal text | NeuralSearch can only reason over the data it receives. |
+| Exact queries | SKU, brand, part number, regulated/compliance terms | Semantic expansion should not break deterministic expectations. |
+| Long-tail queries | Multi-word, natural-language, vague, and conceptual searches | These are often where NeuralSearch creates the clearest value. |
+| Merchandising | Pinned, buried, promoted, suppressed, and campaign results | Business logic should remain intentional after semantic changes. |
+| Explainability | Surprising top results, missing expected results, and low-confidence matches | Helps decide whether to adjust data, semantic settings, or business rules. |
+| Analytics segmentation | Replica, A/B test, or analytics tags | Lets the team isolate NeuralSearch impact from unrelated changes. |

--- a/skills/algolia-neuralsearch/references/neuralsearch-guide.md
+++ b/skills/algolia-neuralsearch/references/neuralsearch-guide.md
@@ -1,0 +1,171 @@
+# NeuralSearch Guide
+
+## Current Docs To Verify
+
+The Algolia docs navigation checked on 2026-06-29 lists NeuralSearch under AI relevance with these areas:
+
+- Get started.
+- Adaptive intent.
+- A/B testing.
+- Limitations.
+- Model training.
+
+Verify current docs before changing live configuration:
+
+- https://www.algolia.com/doc/guides/ai-relevance/neuralsearch/get-started
+- https://www.algolia.com/doc/guides/ai-relevance/neuralsearch/adaptive-intent
+- https://www.algolia.com/doc/guides/ai-relevance/neuralsearch/ab-testing
+- https://www.algolia.com/doc/guides/ai-relevance/neuralsearch/limitations
+- https://www.algolia.com/doc/guides/ai-relevance/neuralsearch/model-training
+
+## Readiness Assessment
+
+Check:
+
+- Plan eligibility and current product availability for the customer's application and desired NeuralSearch mode.
+- Index records include meaningful titles, descriptions, categories, brand, attributes, and content summaries.
+- Important searchable text is not split across missing, empty, or overly noisy fields.
+- Filters, facets, secured attributes, and business rules are already explicit.
+- Custom ranking does not overpower the relevance behavior you want to evaluate.
+- Current public docs state that click and conversion events are not required to activate NeuralSearch. Without events, NeuralSearch selects semantic attributes from the record structure; with events, it selects and weights attributes from real query-to-record behavior, and the model can be retrained once events accumulate. Verify the chosen mode's current documentation before treating any cold-start, preview, or activation path as available.
+- There is a representative query set and a baseline metric.
+
+## Academy Rollout Path
+
+Use this teaching sequence for customer guidance:
+
+1. Understand what NeuralSearch changes: it helps with semantic, long-tail, conceptual, and natural-language relevance, while traditional keyword behavior still matters for exact and deterministic queries.
+2. Confirm activation readiness: eligibility, data quality, analytics, current event guidance, representative query set, and rollback.
+3. Preview before rollout: compare hybrid and baseline behavior with the evaluation set, then record useful wins, unacceptable matches, and unexplained results.
+4. Test before broad rollout: use a replica, controlled configuration, or A/B test depending on the customer's traffic and risk.
+5. Tune semantic behavior: review semantic settings, attribute priority, and the chosen conservative/broader-reach behavior only where current docs support it.
+6. Validate with real outcomes: compare CTR, conversion, click position, zero-result/no-click behavior, long-tail engagement, and business-owner relevance review.
+7. Optimize continuously with analytics, explainability, merchandising rules, and event improvements.
+
+## Readiness Gates
+
+Use these gates before recommending enablement:
+
+1. Data gate: records contain meaningful titles, descriptions, categories, attributes, and content summaries; noisy or internal fields are not driving semantic matching.
+2. Relevance gate: textual relevance, filters, facets, rules, merchandising, and custom ranking already behave acceptably for important exact queries.
+3. Event gate: click and conversion signals are reliable enough to compare baseline and rollout behavior and to support retraining and Adaptive Intent. Events are not an activation blocker in current docs, but launching without them limits attribute selection, measurement, and optimization; treat missing events as an explicit risk.
+4. Query-set gate: the team has representative head, tail, natural-language, vague, exact, filtered, and no-result queries.
+5. Rollout gate: the team can stage, A/B test, monitor, and roll back.
+
+Missing data, relevance, event, query-set, or rollout gates should become blockers or explicit risks, not footnotes.
+
+## Hybrid Relevance Evidence
+
+NeuralSearch combines keyword and semantic retrieval. Evaluate the combination, rather than treating semantic relevance as a replacement for keyword search.
+
+| Evidence | Ask | Use it to decide |
+| --- | --- | --- |
+| Query class result | Did expected records improve for vague, long-tail, and natural-language intent without harming exact behavior? | Whether NeuralSearch helps the intended query class. |
+| Result origin or score evidence | Is a result supported by keyword matching, semantic similarity, or both, where current diagnostics expose this? | Whether to inspect source text, semantic attributes, keyword settings, or blend behavior. |
+| Business-rule context | Is the position caused by a pin, promotion, suppression, filter, or sort expectation? | Whether the result is a semantic issue at all. |
+| Outcome signal | Did clicks, conversions, no-clicks, or no-results move for the targeted audience? | Whether a promising manual result generalizes. |
+
+For every surprising win or regression, record the query, expected result, actual result, filters, business rules, observed evidence, hypothesis, single change tested, and retest outcome.
+
+## Semantic Attribute Rationale
+
+Select a small set of fields that express the meaning users search for. For each chosen field, state why it belongs, its priority, representative content, and known noise.
+
+| Attribute type | Often useful when it contains | Risk to review |
+| --- | --- | --- |
+| Title or name | The user's primary product, article, or entity language. | Abbreviations, opaque codes, or duplicate variants. |
+| Description or summary | Real user-facing context, use cases, materials, features, or problem statements. | Supplier boilerplate, marketing repetition, or stale copy. |
+| Category or taxonomy | A stable, user-recognizable classification. | Deep internal labels or duplicate category strings. |
+| Structured attributes | Meaningful concepts users describe naturally. | Treat deterministic facets and permissions as filters, not semantic hints. |
+
+Do not add IDs, internal notes, duplicate concatenations, or unreviewed vendor text merely to increase field count. Change one attribute or priority decision per evaluation round.
+
+## Query Evaluation Set
+
+Include:
+
+- Head queries.
+- Long-tail queries.
+- Natural-language queries.
+- Conceptual/vague queries.
+- Exact SKU, brand, part number, or title queries.
+- Typo and synonym queries.
+- Category and browse-like queries.
+- No-result or low-result queries.
+- Queries with filters.
+- Queries with business-rule or merchandising expectations.
+
+For each query, record expected good results, unacceptable results, filters, and business constraints.
+
+## Data And Events Dependencies
+
+NeuralSearch quality often depends on the same foundations as other AI relevance features:
+
+- Clean, semantically meaningful records.
+- Correct searchable attributes and display fields.
+- Stable objectIDs for events and evaluation.
+- Consistent userToken strategy.
+- Search-attributed clicks and conversions. Current public docs do not require events for activation, but events drive semantic attribute selection and weighting, retraining, Adaptive Intent readiness, evaluation, and rollout confidence.
+- A/B testing or staged rollout instrumentation.
+
+Use `$algolia-events-insights` when events are missing or attribution is unclear.
+
+## Optimization Workflow
+
+1. Define the search classes NeuralSearch should improve.
+2. Capture baseline metrics and a representative query set.
+3. Review current NeuralSearch setup docs, limitations, and unsupported features.
+4. Prepare records and settings.
+5. Enable or configure in a safe environment or staged rollout.
+6. Compare keyword and NeuralSearch results by query class, not only aggregate metrics.
+7. Run A/B tests when meaningful traffic exists.
+8. Document tradeoffs, winning configuration, and rollback.
+
+## Configuration And Diagnostics
+
+When the customer needs tuning, guide the agent to inspect:
+
+- Semantic fields: which attributes carry meaning and which introduce noise.
+- Attribute weights or semantic settings where supported by current docs.
+- Baseline keyword behavior for exact, brand, SKU, part number, and compliance-sensitive queries.
+- Long-tail and natural-language queries where NeuralSearch should help most.
+- Pinned, buried, promoted, suppressed, or campaign-driven merchandising rules.
+- Analytics segmentation through replicas, analytics tags, or A/B tests.
+- Explainability/result panels when a result is surprising, missing, or over-promoted.
+
+Do not recommend broad setting changes without a before/after query set and a way to isolate impact.
+
+### Explainability-Led Triage
+
+When a result is unexpected, work in this order:
+
+1. Reproduce the query with the same filters, locale, sort, and user-facing conditions.
+2. Check whether a rule, pin, promotion, suppression, custom ranking, or filter explains the position.
+3. Inspect the available keyword, semantic, and final-score evidence in current diagnostics.
+4. Inspect the record text and selected semantic attributes for missing context or noise.
+5. Change one hypothesis at a time, rerun the query set, and record the decision.
+
+This sequence prevents teams from overwriting intentional merchandising while trying to fix a relevance issue.
+
+## QA Checklist
+
+- Exact-match queries still behave acceptably.
+- Vague and natural-language queries improve without leaking bad matches.
+- Filters and secured data constraints still apply.
+- Merchandising rules and pinned results behave as expected.
+- No-result strategy is still acceptable.
+- Event payloads preserve objectID, index, queryID where needed, and userToken.
+- Analytics and A/B test reporting can isolate NeuralSearch impact.
+- Virtual replicas are not assumed to work with NeuralSearch; sorted NeuralSearch experiences use current documented sort/replica guidance.
+- Explainability or result inspection has been used for surprising wins and regressions.
+- Business rules and merchandising behavior have been checked in semantic and exact-query scenarios.
+- Long-tail performance is reviewed separately from high-volume head queries.
+- Semantic attributes have a documented purpose and priority; noisy, internal, and duplicate fields are excluded or accounted for.
+- Preview or explainability evidence distinguishes keyword, semantic, and hybrid behavior for representative wins and regressions.
+
+## Related Skills
+
+- `$algolia-data-modeling`: record and field readiness.
+- `$algolia-index-configuration`: textual relevance and business ranking.
+- `$algolia-events-insights`: measurement and conversion attribution.
+- `$algolia-release-qa`: rollout and regression checks.

--- a/skills/algolia-release-qa/SKILL.md
+++ b/skills/algolia-release-qa/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: algolia-release-qa
+description: >
+  Algolia launch, regression, and implementation QA. Use when auditing an Algolia build before release, validating relevance changes, checking search UI behavior, verifying event instrumentation, diagnosing analytics gaps, reviewing secured keys, or creating a smoke test plan for search, browse, autocomplete, indexing, and configuration changes. Do NOT use to make live account changes or inspect live account data; use algolia-mcp or algolia-cli first. Do NOT use as the primary implementation skill when the task is clearly data modeling, events setup, InstantSearch, Autocomplete, NeuralSearch, or Agent Studio; use the focused skill first and this skill for final QA.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.3"
+---
+
+# Algolia Release QA
+
+Use this skill before launching or after a risky change. Prioritize defects that affect discoverability, conversion, analytics integrity, security, or operational rollback.
+
+## Customer-Facing Standard
+
+- Lead with launch blockers and high-risk findings, not a generic summary.
+- State what was tested, what was not tested, and what evidence supports each finding.
+- Use public `academy.algolia.com` for learning alignment and public `algolia.com/doc` for current implementation guidance when source-backed context is needed.
+- When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
+- Do not require custom Academy/docs access; use customer-provided sources only as optional context.
+- When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
+- Do not say launch-ready without validating data, settings, UI, events, security, and rollback where relevant.
+- Build an evidence matrix before assigning a release status: evidence must identify the surface, scenario, source, result, owner, and remaining risk.
+
+## Official Companion Skills
+
+- Use official `algolia-mcp` for live search, analytics, recommendations, index discovery, and evidence gathering.
+- Use official `algolia-cli` for settings, rules, synonyms, records, keys, backups, and admin verification.
+- Use official `instantsearch` for UI implementation correctness, framework-specific source-of-truth checks, and frontend search QA.
+- Use official `algobot-cli` for Agent Studio, conversational, RAG, memory, tool, and deployment QA.
+- Use this skill after official tool calls to write severity-led customer findings, owners, fixes, tests run, and residual risk.
+
+## Source-Of-Truth Rules
+
+- Do not mark an implementation launch-ready from screenshots or code alone when data, settings, events, security, or rollback are in scope.
+- Use official tools for live evidence and current docs for feature-specific requirements.
+- Separate verified findings from untested risks. If evidence is missing, say exactly what could not be inspected.
+- For search implementations, use the cross-skill readiness signposts from `algolia-search-implementation` before saying launch-ready, prototype-ready, or ready with documented follow-ups.
+
+## Workflow
+
+1. Read `references/release-qa-checklist.md` for the relevant surface.
+2. Read `references/example-output.md` when writing a customer-facing launch or regression report.
+3. Capture what changed: data model, settings, UI, events, environment, credentials, or deployment.
+4. Test representative happy paths and failure paths.
+5. Verify attribution as a chain: search or browse request, queryID, hit identity and position, event payload, debugger/arrival, and downstream usability.
+6. For experiments, confirm the hypothesis, isolated change, traffic/data sufficiency, event coverage, confidence state, and rollback decision instead of treating a dashboard metric as self-explanatory.
+7. Report findings by severity with concrete reproduction steps, expected behavior, evidence source, and owner.
+8. Write the report so a non-specialist customer can decide what to fix now versus later.
+9. Include residual risk when production data, analytics windows, credentials, or live tools cannot be inspected.
+
+## QA Areas
+
+- Data and indexing: objectIDs, record counts, freshness, replicas, secured/hidden records, partial updates.
+- Relevance: top queries, zero-result queries, filters, facets, synonyms, rules, sort orders, typo tolerance.
+- UI: routing, pagination, empty states, loading/errors, mobile filters, accessibility, analytics attribution.
+- Events: userToken consistency, queryID propagation, positions, conversion taxonomy, duplicate-event risk.
+- Security and operations: API key exposure, secured API keys, environments, settings backup, rollback.
+- AI surfaces: NeuralSearch event prerequisites, semantic/evaluation query regressions, Agent Studio tool authority, memory, guardrails, and feedback loops.
+
+## Algolia Search Readiness Signposts
+
+Use these signposts to decide whether the implementation is launch-ready, prototype-ready, or ready with accepted follow-ups:
+
+- Data contract exists.
+- Index settings match the UI.
+- Records include all display, facet, ranking, merchandising, inventory, and event-attribution fields used by the experience.
+- Autocomplete has source and selection contracts when autocomplete is included.
+- Search results or browse pages handle query, hits, filters, sort, current refinements, recovery, pagination or infinite loading, empty states, loading, and errors when those surfaces are included.
+- Events taxonomy exists.
+- Click events are implemented, validated, or explicitly deferred by the user.
+- Conversion events are planned, implemented, validated, or explicitly deferred by the user.
+- Live index validation queries pass when live data is available.
+- Browser QA passes for the relevant UI surfaces when a browser is available.
+
+If any item is missing, report it as a launch blocker, accepted deferral, or residual risk depending on severity and the user's explicit decisions.
+
+## Anti-Patterns
+
+- Reporting a checklist as passed without evidence, screenshots, payloads, settings exports, query results, or code references.
+- Burying launch blockers under a positive summary.
+- Treating event payload presence as success without checking identity, attribution, duplicate risk, and downstream visibility.
+- Ignoring rollback, environment separation, API-key scope, or secured data because the UI appears to work.
+- Calling an A/B test a win before its data and confidence state support interpretation, or when multiple unrelated changes prevent causal attribution.
+- Marking an event as valid only because it reached the debugger without checking queryID, userToken, objectID, position, duplicate ownership, and downstream feature usability.
+
+## Academy And Customer Education Alignment
+
+When source-backed guidance is needed, search public Academy sources for launch and QA learning objectives and public Algolia docs for data, relevance, UI, events, analytics, security, and AI-readiness details. Convert source guidance into maturity-aware checks and validation artifacts for the customer team.
+
+## Maturity Behavior
+
+- Beginner implementation: focus on whether the basic data, settings, UI, and event paths work at all.
+- Production readiness: lead with launch blockers, evidence matrix, security, rollback, attribution chain, mobile UX, and indexing reliability.
+- Optimization: test representative queries, analytics quality, A/B readiness and confidence, merchandising behavior, and regression risk.
+- AI readiness: verify NeuralSearch event prerequisites and evaluation queries plus Agent Studio data, permissions, tool authority, guardrails, feedback loops, and readiness gates.
+
+## Output Contract
+
+Lead with findings, not a generic summary. Include:
+
+- Severity and affected surface.
+- Evidence or reproduction.
+- Recommended fix.
+- Owner or role needed to fix it.
+- Tests run and tests not run.
+- Evidence matrix and residual risk.
+
+If no issues are found, say so clearly and identify the remaining risks.

--- a/skills/algolia-release-qa/agents/openai.yaml
+++ b/skills/algolia-release-qa/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia Release QA"
+  short_description: "Validate Algolia implementations before launch"
+  default_prompt: "Use $algolia-release-qa to audit my Algolia implementation before launch."

--- a/skills/algolia-release-qa/evals/evals.json
+++ b/skills/algolia-release-qa/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "algolia-release-qa",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We launch our new Algolia-powered search Monday (index: garden_supplies_prod, React InstantSearch results page + autocomplete, click/conversion events wired last week). Can you sign off? I can share code, and screenshots of the dashboard showing events arriving. Nobody has done a settings backup and we haven't decided what happens if relevance tanks post-launch.",
+      "expected_output": "The response does not sign off from code and screenshots alone: it applies the source-of-truth rule that data, settings, events, security, and rollback in scope require live evidence via algolia-mcp/algolia-cli, and it leads with the launch blockers — no settings backup and no rollback plan. It works through the readiness signposts (data contract, settings/UI match, event validation beyond arrival, autocomplete contracts, UI states), builds an evidence matrix distinguishing verified findings from untested risks, states what was and was not tested, and reports findings by severity with owners rather than a generic summary.",
+      "files": [],
+      "expectations": [
+        "Declines to mark the build launch-ready from code and screenshots alone; requires live evidence via algolia-mcp or algolia-cli for data, settings, and events",
+        "Leads with launch blockers — the missing settings backup and missing rollback plan — instead of burying them under a positive summary",
+        "Checks event readiness beyond arrival: queryID propagation, userToken consistency, positions, and duplicate-event risk, not just dashboard visibility",
+        "References the cross-skill readiness signposts (data contract exists, settings match UI, autocomplete source/selection contracts, UI empty/error states) when assessing status",
+        "States explicitly what was tested and what was not tested, with residual risk for anything uninspectable",
+        "Reports findings by severity with reproduction/evidence and an owner for each fix"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Good news - our A/B test 'won'! We tested the new customRanking on searches for 2 weeks, conversion is up 4%. During the same sprint we also shipped a redesigned PDP and turned on a promo banner. VP wants a slide saying Algolia drove the 4%. Also mid-test we paused it for 3 days during a sale and restarted. Can you confirm the win?",
+      "expected_output": "The response does not confirm the win: multiple unrelated changes (PDP redesign, promo banner) shipped alongside the ranking change prevent causal attribution, and pausing/restarting the test breaks the assumption of a continuous experiment. It checks the experiment against the skill's criteria — hypothesis, isolated change, traffic/data sufficiency, event coverage, confidence state, and rollback decision — routes retrieval of the actual test data/confidence to algolia-mcp, and recommends what a clean re-test would look like, stating clearly why the 4% claim cannot currently be attributed to the ranking change.",
+      "files": [],
+      "expectations": [
+        "Refuses to attribute the 4% lift to the customRanking change because the PDP redesign and promo banner shipped in the same window, preventing causal attribution",
+        "Flags the mid-test pause/restart as invalidating treatment of the test as one continuous experiment",
+        "Evaluates the experiment against explicit criteria: hypothesis, isolated change, data/traffic sufficiency, event coverage, and confidence state",
+        "Routes retrieval of live A/B test data, confidence, or analytics to algolia-mcp rather than asserting numbers",
+        "Recommends a corrective path (e.g. clean isolated re-test or explicit caveats) rather than simply approving or rejecting the slide"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "We just did a big reindex of our knowledge base (kb_articles_prod) after changing objectIDs and adding secured filters for customer-tier gating. Support says 'search seems fine'. What should we actually smoke-test before we tell everyone it's done?",
+      "expected_output": "The response turns 'seems fine' into a concrete smoke-test plan across the QA areas: data/indexing (record counts vs source, objectID integrity after the change, secured/hidden records actually excluded), relevance (top queries, zero-result queries, filters), UI (empty states, routing), events (queryID propagation broken by new objectIDs, event attribution against the new IDs), and security (secured filters actually enforce tier gating — tested with the wrong tier, not just the right one). It routes live checks to algolia-mcp/algolia-cli, flags that the objectID change likely broke event attribution continuity, and defines what evidence marks each check passed.",
+      "files": [],
+      "expectations": [
+        "Produces a concrete smoke-test plan spanning data/indexing, relevance, UI, events, and security rather than accepting 'seems fine'",
+        "Includes verifying secured filter enforcement negatively (a lower-tier user must NOT see gated articles), not just positive access",
+        "Flags the objectID change as a risk to event attribution and downstream analytics that must be re-validated",
+        "Checks record counts/freshness against the source and runs top and zero-result queries as relevance evidence",
+        "Routes live index and analytics inspection to algolia-mcp or algolia-cli and identifies residual risk for anything not inspectable"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-release-qa/references/example-output.md
+++ b/skills/algolia-release-qa/references/example-output.md
@@ -1,0 +1,50 @@
+# Example Output: Customer-Readable QA Report
+
+Use this shape when reporting launch readiness.
+
+## Summary
+
+Launch should wait until the blocker and high-severity event issue are fixed. Search relevance is usable for the tested query set, but analytics and AI-readiness are not reliable yet because click attribution is incomplete.
+
+## Findings
+
+| Severity | Surface | Finding | Evidence | Recommended fix | Owner |
+| --- | --- | --- | --- | --- | --- |
+| Blocker | Security | Admin-capable key appears in the browser bundle. | Client-side network inspection shows a key with write-capable permissions. | Replace it with a search-only or secured search key and rotate the exposed key. | Developer or Algolia admin |
+| High | Events | Search result clicks do not include `queryID`. | Click payload contains `objectID` and `userToken`, but no `queryID`. | Enable queryID retrieval on searches and pass the clicked hit's `queryID` to the event. | Frontend developer |
+| Medium | Relevance | Top query `waterproof trail shoe` ranks an unavailable product first. | Tested query returns an out-of-stock item above available alternatives. | Add availability as a custom ranking or filtering strategy according to merchandising rules. | Search owner |
+| Low | UI | Empty state gives no next step. | No-result query shows a blank results area. | Add alternate query/category suggestions. | Frontend or content owner |
+
+## Evidence Matrix
+
+| Surface | Scenario | Evidence | Status | Residual risk |
+| --- | --- | --- | --- | --- |
+| Search relevance | `waterproof trail shoe` | Saved result set and availability filter review. | Needs follow-up | Long-tail and locale scenarios not yet run. |
+| Events | Search -> click -> add to cart | Browser payload and debugger show queryID, objectID, index, position, and userToken. | Click ready; conversion incomplete | Purchase path is server-side and not yet inspected. |
+| Security | Client bundle | Key review found an admin-capable key. | Blocked | Key rotation and secured-key retest required. |
+| Rollback | Settings change | Exported settings and owner runbook available. | Ready | Production restore has not been rehearsed. |
+
+## Tests Run
+
+- 10 top revenue queries.
+- 5 known problem queries.
+- Category browse with filters.
+- Mobile filter and sort behavior.
+- Click and add-to-cart event payload inspection.
+- Client-side key exposure check.
+
+## Tests Not Run
+
+- Production analytics trend review because the event fix is required first.
+- A/B test analysis because no experiment is active.
+- Purchase event validation because test checkout access was unavailable.
+
+## Launch Recommendation
+
+Do not launch broadly yet. Fix the exposed key and missing click attribution, then rerun security and event QA. Relevance and UI issues can launch with owner acceptance if the blocker and high issue are resolved.
+
+## Smallest Retest
+
+1. Confirm the browser uses only a search-only or secured key after rotation.
+2. Search, click a result, and complete the primary conversion path; verify the full attribution chain and duplicate-event ownership.
+3. Rerun the top-query, known-problem-query, and mobile empty-state checks.

--- a/skills/algolia-release-qa/references/release-qa-checklist.md
+++ b/skills/algolia-release-qa/references/release-qa-checklist.md
@@ -1,0 +1,129 @@
+# Release QA Checklist
+
+## Severity Rubric
+
+- Blocker: launch should not proceed. Examples: admin key exposed, secured records visible to the wrong user, event attribution entirely missing for required AI/personalization feature, production indexing can delete or corrupt records with no rollback.
+- High: launch risk is material and should be fixed before broad rollout. Examples: top revenue queries return clearly wrong results, purchase events duplicate, mobile filters unusable, key facets missing.
+- Medium: launch can proceed only with owner acceptance and follow-up. Examples: some long-tail queries weak, low-result UX rough, noncritical event metadata missing, incomplete analytics segmentation.
+- Low: polish or monitoring follow-up. Examples: minor label issues, helpful additional QA coverage, documentation cleanup.
+
+## Sample Findings
+
+Use this shape in reports:
+
+| Severity | Surface | Finding | Evidence | Recommended fix | Owner |
+| --- | --- | --- | --- | --- | --- |
+| Blocker | Security | Client exposes an admin-capable API key. | Browser bundle contains a key with write/admin capability. | Replace with search-only or secured search key; rotate exposed key. | Developer or Algolia admin |
+| High | Events | Click events omit queryID. | Network payload includes objectID and userToken but no queryID after search result click. | Enable click analytics on search and pass queryID from hit to event. | Frontend developer |
+| High | Data | Product variants are collapsed, hiding account-specific availability. | B2B account filter shows unavailable SKUs as purchasable. | Add account/availability filtering or separate account-aware records. | Data feed owner |
+| Medium | Relevance | Synonym rule broadens support query too aggressively. | Query "returns" ranks unrelated shipping policy above return policy. | Scope synonym or add tested rule for return-policy intent. | Search owner |
+| Low | UI | Empty state does not suggest next action. | No-result query renders blank results area. | Add empty-state copy and alternate navigation. | Frontend or content owner |
+
+## Customer-Readable Report Shape
+
+Keep the report direct:
+
+- What blocks launch.
+- What can launch with a documented risk.
+- What was tested.
+- What was not tested and why.
+- Who needs to act next.
+- The smallest retest needed after fixes.
+
+## Evidence Matrix
+
+Do not report a surface as passed based on an impression. Capture evidence that another owner can reproduce.
+
+| Surface | Scenario | Evidence source | Pass condition | Owner | Residual risk |
+| --- | --- | --- | --- | --- | --- |
+| Search/relevance | Top and known-problem query | Saved query result, settings export, or screenshot with context | Expected records and constraints hold. | Search owner | Untested long-tail or locale behavior. |
+| Events | Search -> click -> conversion | Request/response, event payload, debugger, and analytics evidence | Identity and attribution survive the full chain. | Frontend/backend analytics owner | Downstream data latency or untested server path. |
+| UI | Mobile filter, sort, or empty state | Browser recording or screenshot with viewport | User can refine, recover, and continue. | Frontend owner | Device/browser coverage gap. |
+| Security | Restricted user/account scenario | Key/config review and permission-boundary test | No restricted record or capability leaks. | Security or Algolia admin | Unavailable production identity path. |
+| Operations | Relevance or data rollback | Settings backup, runbook, and restore rehearsal | Owner can revert safely. | Search/data owner | Unrehearsed production rollback. |
+
+## Regression Charter
+
+Before testing, identify the changed surface and its likely blast radius: data, relevance, UI, events, AI, and operations. Use the charter to decide which checks are mandatory, which are not applicable, and which remain untested.
+
+## Data And Indexing
+
+- Record count matches source expectations.
+- ObjectIDs are stable and unique.
+- Required searchable, display, filter, and ranking fields exist on representative records.
+- Hidden, unavailable, secured, or out-of-region records behave correctly.
+- Replicas are present and settings match their intended sort behavior.
+- Incremental updates and full reindex paths both complete successfully.
+- Indexing tasks are awaited where the application depends on fresh data.
+
+## Relevance
+
+- Top business queries return expected results.
+- Known problem queries are included.
+- No-result and low-result queries have acceptable UX or content strategy.
+- Searchable attribute order matches user intent.
+- Custom ranking metrics break ties as intended.
+- Facets are normalized and useful.
+- Rules, synonyms, typo tolerance, and optional filters are scoped and tested.
+- Category/browse pages use correct filters and analytics segmentation.
+
+## Search UI
+
+- Search box, results, facets, current refinements, sort, pagination/infinite hits, and empty states work.
+- URL routing preserves query/refinement state when required.
+- Mobile filters and sort controls are usable.
+- Loading and error states are visible.
+- Result cards expose correct links, labels, prices, availability, and images.
+- Accessibility basics are covered: labels, focus order, keyboard interaction, link names.
+
+## Autocomplete
+
+- Sources appear in the intended order.
+- Keyboard, mouse, touch, Escape, Enter, and blur behavior work.
+- Selection behavior is correct per source.
+- Mobile detached mode works if enabled.
+- No suggestions and slow network states are acceptable.
+- Autocomplete handoff to InstantSearch or routing does not create state loops.
+
+## Events And Analytics
+
+- Search requests needing attribution have click analytics enabled.
+- Click events include correct index, objectID, queryID, position, and userToken.
+- Conversion events represent business-defined conversions.
+- Server-side conversions can be tied back to userToken/objectID/index where required.
+- Duplicate events are not emitted by both frontend and backend.
+- Event names are stable, readable, and segmented enough for analytics.
+
+### Attribution Chain
+
+Verify each link, in order:
+
+1. The search or browse request returns a `queryID` when attribution is needed.
+2. The rendered hit preserves its `objectID`, index, and displayed one-based position.
+3. The click or conversion payload uses the same durable `userToken` and includes `queryID` when it is search-attributed.
+4. The event arrives in the debugger or another arrival surface.
+5. The event is usable for the claimed analytics, personalization, A/B test, NeuralSearch, or AI-feedback feature.
+
+A 200 response or debugger entry proves arrival, not the whole chain.
+
+## Security And Operations
+
+- Search-only keys are exposed client-side, not admin keys.
+- Secured API keys or filters protect user/account-restricted data.
+- Environment variables are used for sensitive IDs and keys according to project conventions.
+- Production settings changes have a backup or repeatable config file.
+- Rollback steps are documented.
+- Monitoring or logs can detect failed indexing, stale data, or event drop-offs.
+
+## Experiment And AI QA
+
+- A/B test states the hypothesis, one isolated change, control, variant, traffic split, target metric, guardrail metric, duration/sample-size approach, and rollback decision.
+- Event coverage is sufficient for test metrics; no-data or low-confidence outcomes are reported as inconclusive rather than wins.
+- NeuralSearch meets current feature prerequisites and passes exact, semantic, filtered, merchandised, and no-result evaluation queries.
+- Agent Studio has a narrow job, least-privilege tools, grounded retrieval, memory/retention decision, guardrails, safe fallback, approved domains, and feedback plan.
+
+## Source Notes
+
+- Relevance diagnostics should cover searchable attributes, custom ranking, rules, synonyms, facets, analytics, and A/B testing: https://www.algolia.com/doc/guides/managing-results/relevance-overview
+- Event QA must distinguish events with and without queryID and account for feature requirements: https://www.algolia.com/doc/guides/sending-events/concepts/event-types
+- InstantSearch routing and event behavior need explicit testing: https://www.algolia.com/doc/guides/building-search-ui/going-further/routing-urls/js and https://www.algolia.com/doc/guides/building-search-ui/events/js

--- a/skills/algolia-search-implementation/SKILL.md
+++ b/skills/algolia-search-implementation/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: algolia-search-implementation
+description: >
+  Execution checklist for net-new Algolia search, browse, autocomplete, ecommerce search, recommendations, personalization, Dynamic Re-Ranking, or search UI builds. Use during a greenfield build to keep data contract, event taxonomy, index configuration, UI, and release QA visible as explicit checkpoints with completion signposts and suggested artifacts, so agents proceed deliberately and document tradeoffs and deferrals. Do NOT use as the entry point for Algolia work; start with algolia-discovery-planning, which maps the request to the lifecycle and loads this skill for net-new builds.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.2"
+---
+
+# Algolia Search Implementation
+
+Use this skill as the execution checklist for net-new Algolia search builds, loaded from `algolia-discovery-planning` once the phase plan marks a greenfield implementation in scope. Its job is to make data, events, index configuration, UI, and release QA visible decision points, especially when an agent needs to move quickly or proceed with provisional assumptions.
+
+Use the whole Algolia lens: data and events are not side quests. The data contract determines what search can retrieve, rank, filter, display, merchandise, secure, and attribute. The event foundation determines whether analytics, personalization, Recommend, Dynamic Re-Ranking, NeuralSearch evaluation, and Agent Studio feedback loops can be trusted. Let UI and AI feature decisions inherit from those foundations instead of discovering them late.
+
+## Recommended Workflow
+
+For any net-new Algolia search, browse, autocomplete, ecommerce, recommendations, personalization, or Dynamic Re-Ranking implementation, work through these checkpoints in order when practical:
+
+1. Data contract checkpoint: use `algolia-data-modeling`.
+2. Event instrumentation checkpoint: use `algolia-events-insights`.
+3. Index configuration checkpoint: use `algolia-index-configuration`.
+4. UI implementation checkpoint:
+   - Choosing the UI library, framework fit, SSR/routing strategy, or mobile SDKs: use `algolia-ui-libraries`.
+   - Autocomplete or typeahead: use `algolia-autocomplete`.
+   - Search results page, browse page, filters, facets, routing, sort, pagination, or current refinements: use `algolia-instantsearch-ui`.
+   - Current framework APIs and production code details: use the official `instantsearch` skill alongside `algolia-instantsearch-ui` or `algolia-autocomplete`.
+5. Release QA checkpoint: use `algolia-release-qa`.
+
+Before UI work, pause long enough to identify the data contract and event taxonomy. If the user asks for a quick prototype or the information is unavailable, proceed with a minimal provisional contract, name the assumptions, and record what must be revisited before launch.
+
+## Foundation Lens
+
+When using the full skills library, orient the work in this order:
+
+1. Data shape: records, variants, objectIDs, searchable/display fields, facets, ranking signals, inventory, permissions, and update ownership.
+2. Event shape: userToken strategy, click and conversion taxonomy, queryID/objectID/position preservation, ownership, deduplication, and validation.
+3. Relevance and UI: settings, widgets, routing, filters, autocomplete sources, and result interactions that match the data and event contracts.
+4. AI readiness: NeuralSearch, Dynamic Re-Ranking, Recommend, personalization, and Agent Studio behavior evaluated against data quality and behavioral signals.
+5. QA: evidence that data, events, settings, UI, security, and rollback are understood.
+
+## Completion Signposts
+
+Use these signposts when deciding whether to call the implementation ready, prototype-ready, or ready with documented follow-ups:
+
+- Data contract exists.
+- Index settings match the UI.
+- Records include all display, facet, ranking, merchandising, inventory, and event-attribution fields used by the experience.
+- Autocomplete has source, ordering, selection, routing, and event-handoff contracts when autocomplete is included.
+- Search results or browse pages handle query, hits, filters, sort, current refinements, pagination or infinite loading, empty states, recovery, loading, and error states when those surfaces are included.
+- Events taxonomy exists.
+- Click events are implemented, validated, or explicitly deferred by the user.
+- Conversion events are planned, implemented, validated, or explicitly deferred by the user.
+- Live index validation queries pass when live data is available.
+- Browser QA passes for the relevant UI surfaces when a browser is available.
+
+## Suggested Artifacts
+
+For production-oriented work, create or update:
+
+- `algolia/index-contract.md` or an equivalent index contract artifact.
+- `algolia/search-event-taxonomy.md` or an equivalent event taxonomy artifact.
+- A release QA note or report covering data, settings, UI, events, security, and rollback where relevant.
+
+For small demos or prototypes, produce the minimal contract:
+
+- One paragraph data contract.
+- One table of events.
+- Three validation queries.
+- Explicit deferred production concerns.
+
+## Decision Behavior
+
+- If sample records, UI fields, objectID strategy, event attribution fields, or userToken strategy are missing, state assumptions and create a provisional artifact instead of silently skipping the decision.
+- If the user asks to defer events or conversions, record the deferral explicitly with owner, risk, and follow-up validation.
+- If live Algolia inspection or writes are needed, route through Algolia MCP, Algolia CLI, or official Algolia skills first, then return to this guided workflow.
+- If a task is only an audit of an existing implementation, start with `algolia-release-qa`, then route findings back to data, events, index configuration, autocomplete, or InstantSearch skills as needed.
+
+## Output Contract
+
+Return a checkpoint-by-checkpoint implementation summary:
+
+- Data contract status.
+- Event taxonomy status.
+- Index configuration status.
+- UI implementation status.
+- Release QA status.
+- Explicit deferrals and risks.
+- Next validation step.

--- a/skills/algolia-search-implementation/agents/openai.yaml
+++ b/skills/algolia-search-implementation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia Search Implementation"
+  short_description: "Guide Algolia search builds from discovery through launch"
+  default_prompt: "Use $algolia-search-implementation to sequence the data, events, index configuration, UI, and release QA decision points for my Algolia search implementation."

--- a/skills/algolia-search-implementation/evals/evals.json
+++ b/skills/algolia-search-implementation/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "algolia-search-implementation",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We're building search for our B2B electrical parts store from scratch. React storefront, catalog export is a CSV with ~60k part numbers, customers search by SKU or description. I want a search page with filters (brand, voltage, category), autocomplete, and eventually personalization. Walk me through the build.",
+      "expected_output": "The response works through the net-new build as explicit checkpoints in order: data contract (algolia-data-modeling), event instrumentation (algolia-events-insights), index configuration (algolia-index-configuration), UI (algolia-ui-libraries / algolia-autocomplete / algolia-instantsearch-ui, with the official instantsearch skill for code details), and release QA (algolia-release-qa). It treats data and events as foundations rather than side quests — noting personalization depends on the event foundation — pauses on the data contract and event taxonomy before UI, and returns a checkpoint-by-checkpoint status with deferrals and next validation step.",
+      "files": [],
+      "expectations": [
+        "Presents the build as ordered checkpoints: data contract, events, index configuration, UI, release QA — not as a single UI coding task",
+        "Names the sibling skill that owns each checkpoint (algolia-data-modeling, algolia-events-insights, algolia-index-configuration, algolia-autocomplete/algolia-instantsearch-ui/algolia-ui-libraries, algolia-release-qa) rather than stopping at the first match",
+        "Addresses the data contract (record shape, objectID, searchable/facet fields like brand, voltage, category, SKU exactness) before or alongside UI decisions",
+        "Connects the personalization goal to event readiness (userToken strategy, click/conversion taxonomy) instead of deferring events silently",
+        "References completion signposts or suggested artifacts (index contract, event taxonomy, release QA note) for calling the work ready",
+        "Ends with a checkpoint-by-checkpoint summary including explicit deferrals, risks, or next validation step"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I need a quick demo of Algolia search over our recipe blog content for a stakeholder meeting Thursday. ~800 posts, I have a JSON dump. Don't overthink it, I just need something that looks real.",
+      "expected_output": "The response respects the prototype timeline but does not silently skip foundations: it proceeds with a minimal provisional contract — a one-paragraph data contract, a small table of planned events, roughly three validation queries — names its assumptions explicitly, and records the deferred production concerns (events, secured keys, full QA) that must be revisited before launch. It does not fabricate live index state.",
+      "files": [],
+      "expectations": [
+        "Proceeds with a minimal provisional data contract instead of either skipping the contract entirely or demanding full production rigor for a demo",
+        "States assumptions explicitly (e.g. objectID strategy, display fields) rather than deciding silently",
+        "Produces or proposes the minimal prototype artifacts: a short data contract, an event table or explicit event deferral, and a few validation queries",
+        "Records deferred production concerns (e.g. event validation, environments, security, QA) with a note that they must be revisited before launch",
+        "Distinguishes prototype-ready from launch-ready when describing completion"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "We already have Algolia live on our marketplace (indices: mp_listings_prod, mp_sellers_prod) but conversion attribution seems broken and nobody trusts the analytics. Can you audit what we have and fix it?",
+      "expected_output": "Because this is an audit of an existing implementation rather than a net-new build, the response starts with algolia-release-qa and routes findings back to the focused skills (algolia-events-insights for the attribution problem, plus data/index/UI skills as needed). Any live inspection of the prod indices or events health is routed through algolia-mcp or algolia-cli. The response frames the attribution issue in terms of queryID/objectID/position/userToken preservation.",
+      "files": [],
+      "expectations": [
+        "Recognizes the task as an audit and starts with algolia-release-qa rather than the greenfield checkpoint sequence",
+        "Routes the attribution findings to algolia-events-insights (and other focused skills as needed) rather than handling everything inside this skill",
+        "Routes live index/analytics inspection through algolia-mcp or algolia-cli instead of guessing account state",
+        "Mentions the concrete attribution fields likely at fault: queryID, objectID, position, and/or userToken consistency",
+        "Does not claim the analytics are fixed or trustworthy without a validation step"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-ui-libraries/SKILL.md
+++ b/skills/algolia-ui-libraries/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: algolia-ui-libraries
+description: >
+  Living selector and reference workflow for current Algolia UI libraries. Use when choosing, installing, upgrading, implementing, or auditing InstantSearch.js, React InstantSearch, Vue InstantSearch, InstantSearch Android, InstantSearch iOS, Algolia for Flutter, Autocomplete, legacy Angular InstantSearch audits or migrations, DocSearch-style autocomplete, routing, SSR, events, mobile SDKs, framework integrations, UI examples, styling, performance, secured API keys, or frontend search library architecture. Do NOT use as a frozen API reference or package-version source; verify current docs. Do NOT use for full implementation once the library is selected; use algolia-instantsearch-ui, algolia-autocomplete, or the official instantsearch skill.
+license: MIT
+metadata:
+  author: algolia
+  version: "0.3"
+---
+
+# Algolia UI Libraries
+
+Use this skill to choose the right current Algolia UI library and docs path. Do not treat this skill as a frozen API reference or package-version source.
+
+## Customer-Facing Standard
+
+- Verify current public docs before recommending package names, imports, SSR patterns, routing, or upgrade steps.
+- Choose the library from the customer journey and framework, not from generic preference.
+- Use public `academy.algolia.com` for learning alignment and public `algolia.com/doc` for current implementation guidance when source-backed context is needed.
+- When an Academy metadata reference pack is available, use only its `title`, `url`, `course`, `module`, `learning_objectives`, and `updated_at` fields for structure. If it is stale or no match exists, fall back to live Academy/docs lookup. Do not treat cached metadata as course content or implementation authority.
+- Do not require custom Academy/docs access; use customer-provided sources only as optional context.
+- When live Algolia data, analytics, index inspection, settings changes, or account actions are needed, use Algolia MCP, the Algolia CLI, or official Algolia skills for the live operation, then apply this skill to interpret results and validate the customer-ready implementation path.
+- Route to InstantSearch, Autocomplete, Events, or Release QA when implementation depth is needed.
+
+## Official Companion Skills
+
+- Use official `instantsearch` for production implementation, source-of-truth checks, framework-specific rules, and code-level InstantSearch or Autocomplete work.
+- Use this skill before the official implementation step to choose the right current UI path and after implementation to validate routing, SSR, events, and upgrade assumptions.
+
+## Source-Of-Truth Rules
+
+- Check `https://www.algolia.com/doc/llms.txt`, current public docs, installed package metadata, or official skills before giving install commands, imports, APIs, or upgrade instructions.
+- Do not freeze package versions in the skill output unless the project already pins them or current docs/package metadata were checked.
+- If docs cannot be checked, provide the decision path and mark exact commands as needing verification.
+
+## Workflow
+
+1. Read `references/ui-library-selector.md` before choosing or changing a library.
+2. Identify the app platform and framework: vanilla JS, React, Next.js, Vue, Angular, Android, iOS, Flutter, React Native, Laravel/Vue, or documentation search.
+3. Choose the UI library by experience shape:
+   - Full search or browse results: InstantSearch family.
+   - Typeahead, query suggestions, recent searches, or federated suggestions: Autocomplete.
+   - Documentation/site search: DocSearch-style Autocomplete only if that matches the product.
+   - Native/mobile search: InstantSearch Android, iOS, or Flutter Helper.
+4. Verify the current official docs before install, imports, SSR, routing, event, or upgrade changes.
+5. Route to the implementation skill:
+   - `$algolia-instantsearch-ui` for full results/search/browse UI.
+   - `$algolia-autocomplete` for typeahead and suggestion experiences.
+   - `$algolia-events-insights` for click/conversion attribution.
+   - `$algolia-release-qa` before launch.
+
+## Questions To Ask
+
+- What framework and version does the app use?
+- Is the experience a full results page, browse/category page, autocomplete, federated search, mobile UI, or docs search?
+- Does the project need SSR, URL routing, backend search, secured API keys, or mobile/native behavior?
+- Which index, replicas, facets, filters, and sort options must the UI expose?
+- Which events and analytics features are required?
+- Is this a fresh implementation, migration, or package upgrade?
+
+## Standards
+
+- Do not copy large Algolia docs into the skill. Link to current docs and summarize decision logic.
+- Do not hard-code package versions from memory. Inspect the project and verify current docs/package metadata before changing dependencies.
+- Prefer the framework-specific official guide over generic snippets.
+- Preserve event attribution: queryID, objectID, index, position, and userToken where needed.
+- Include routing, empty/loading/error states, mobile behavior, accessibility, and performance in QA.
+
+## Anti-Patterns
+
+- Choosing a library because it is familiar instead of matching the framework and user journey.
+- Mixing Autocomplete and InstantSearch responsibilities without a clear handoff contract.
+- Treating mobile/native apps as web InstantSearch ports when native libraries are available.
+- Recommending SSR, routing, or secured-key patterns from memory.
+
+## Academy And Customer Education Alignment
+
+When source-backed guidance is needed, search public Academy sources for UI library learning objectives and public Algolia docs for current docs paths, package guidance, framework patterns, and implementation prerequisites. Do not freeze package versions or copy large docs into the answer. Map the request to maturity level and use case before recommending a library or upgrade path.
+
+## Output Contract
+
+Return the selected library, why it fits, official docs to use, install/upgrade assumptions, implementation plan, event/routing/security notes, and QA checklist. Call out any docs that must be verified live before the agent touches code.

--- a/skills/algolia-ui-libraries/agents/openai.yaml
+++ b/skills/algolia-ui-libraries/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Algolia UI Libraries"
+  short_description: "Select current Algolia UI libraries"
+  default_prompt: "Use $algolia-ui-libraries to choose and validate the right current Algolia UI library for my search experience."

--- a/skills/algolia-ui-libraries/evals/evals.json
+++ b/skills/algolia-ui-libraries/evals/evals.json
@@ -1,0 +1,32 @@
+{
+  "skill_name": "algolia-ui-libraries",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Team debate: we're adding search to our Nuxt 3 storefront (Vue 3). One dev wants to use InstantSearch.js because he used it at his last job, another says just use plain algoliasearch and build the UI ourselves. We need a full results page with facets, URL routing, and SSR for SEO. Which library should we actually use?",
+      "expected_output": "The response chooses the library from the framework and journey rather than familiarity: for a Vue 3/Nuxt full results page with facets, routing, and SSR, it points to Vue InstantSearch (flagging the familiarity-driven InstantSearch.js pick as an anti-pattern in a Vue app, and hand-rolled UI as losing routing/facet/state work). It verifies or explicitly marks for verification the current docs before giving install commands or SSR patterns, avoids pinning package versions from memory, and routes the actual build to algolia-instantsearch-ui and the official instantsearch skill.",
+      "files": [],
+      "expectations": [
+        "Recommends the Vue InstantSearch path based on the Vue 3/Nuxt framework and full-results-page journey, not developer familiarity",
+        "Flags choosing InstantSearch.js in a Vue app because it is familiar as a mismatch, per the skill's anti-patterns",
+        "Addresses the SSR and URL routing requirements as part of the library decision",
+        "Does not hard-code package versions or install commands from memory; verifies current docs or explicitly marks commands as needing live verification",
+        "Routes implementation depth to algolia-instantsearch-ui and/or the official instantsearch skill after the library choice",
+        "Explains why building a custom UI on bare algoliasearch sacrifices routing, facet, and state management work"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "We have an old Angular 12 app using angular-instantsearch and we're also kicking off a new native iOS app that needs product search. What do we do about the Angular thing (upgrade? migrate?) and what should the iOS team use - can they just wrap our web search page in a webview?",
+      "expected_output": "The response knows Angular InstantSearch is deprecated and lays out an audit/migration decision path (e.g. toward InstantSearch.js within Angular or another supported route), marking exact steps as needing verification against current docs. For iOS, it steers to the native InstantSearch iOS library rather than a webview port, per the anti-pattern about treating mobile apps as web InstantSearch ports. It returns the output contract: selected libraries, why they fit, official docs to consult, and what must be verified live before touching code.",
+      "files": [],
+      "expectations": [
+        "Identifies Angular InstantSearch as deprecated/legacy and frames the work as an audit or migration rather than a routine upgrade",
+        "Recommends the native InstantSearch iOS library for the iOS app instead of wrapping the web search page in a webview",
+        "Verifies current public docs or explicitly marks migration steps and install commands as needing live verification before use",
+        "Asks about or accounts for requirements like events, routing, and secured keys in the recommendation",
+        "Returns the decision with rationale, the official docs paths to use, and routing to the implementation skills for the build phase"
+      ]
+    }
+  ]
+}

--- a/skills/algolia-ui-libraries/references/ui-library-selector.md
+++ b/skills/algolia-ui-libraries/references/ui-library-selector.md
@@ -1,0 +1,119 @@
+# UI Library Selector
+
+This reference is intentionally a living selector, not a copied docs dump. Use official docs for current APIs, install commands, imports, and version-specific behavior.
+
+## Current Docs Index
+
+Algolia exposes an LLM-friendly docs index:
+
+- https://www.algolia.com/doc/llms.txt
+
+Check this first when docs paths or names might have changed.
+
+## Library Choice
+
+### Full Search Or Browse UI
+
+Use InstantSearch when building:
+
+- Search results pages.
+- Category or browse pages.
+- Faceted navigation.
+- Sort-by and replica-backed sort.
+- Pagination or infinite hits.
+- Current refinements.
+- URL-synced search state.
+- Search UI that needs click/conversion events.
+
+Official docs:
+
+- InstantSearch.js overview: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js
+- InstantSearch.js install: https://www.algolia.com/doc/guides/building-search-ui/installation/js
+- React InstantSearch install: https://www.algolia.com/doc/guides/building-search-ui/installation/react
+- Vue InstantSearch install: https://www.algolia.com/doc/guides/building-search-ui/installation/vue
+- Angular getting started (InstantSearch.js in Angular): https://www.algolia.com/doc/guides/building-search-ui/getting-started/angular
+
+Angular note: the legacy Angular InstantSearch package is not compatible with the latest Angular versions. For Angular apps, use InstantSearch.js with connectors inside Angular services and components, per the Angular getting-started guide above. Treat existing Angular InstantSearch code as a migration candidate, not a target for new work.
+- InstantSearch events: https://www.algolia.com/doc/guides/building-search-ui/events/js
+- React InstantSearch events: https://www.algolia.com/doc/guides/building-search-ui/events/react
+- Vue InstantSearch events: https://www.algolia.com/doc/guides/building-search-ui/events/vue
+
+### React And Next.js
+
+Use React InstantSearch for React apps. For Next.js or SSR, verify current Next.js/SSR docs before coding.
+
+Official docs:
+
+- React InstantSearch getting started: https://www.algolia.com/doc/guides/building-search-ui/getting-started/react
+- React routing: https://www.algolia.com/doc/guides/building-search-ui/going-further/routing-urls/react
+- React SSR: https://www.algolia.com/doc/guides/building-search-ui/going-further/server-side-rendering/react
+- React secured API keys: https://www.algolia.com/doc/guides/building-search-ui/going-further/api-keys-security/react
+- InstantSearchNext API reference: https://www.algolia.com/doc/api-reference/widgets/instantsearch-next/react
+- createInstantSearchRouterNext API reference: https://www.algolia.com/doc/api-reference/widgets/instantsearch-next-router/react
+
+### Autocomplete And Typeahead
+
+Use Autocomplete when the primary interaction is typing into a search box and showing suggestions before a full result page.
+
+Good fits:
+
+- Query suggestions.
+- Recent searches.
+- Popular searches.
+- Product/content/category suggestions.
+- Federated autocomplete.
+- InstantSearch handoff from an input.
+- Documentation/site search patterns.
+
+Official docs:
+
+- Autocomplete overview: https://www.algolia.com/doc/ui-libraries/autocomplete/introduction/what-is-autocomplete
+- Autocomplete API reference: https://www.algolia.com/doc/api-reference/widgets/autocomplete/react
+- InstantSearch autocomplete pattern JS: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/autocomplete/js
+- InstantSearch autocomplete pattern React: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/autocomplete/react
+- InstantSearch autocomplete pattern Vue: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/autocomplete/vue
+
+### Mobile And Native
+
+Use native/mobile UI libraries when building mobile app search surfaces rather than forcing web InstantSearch patterns into native UI.
+
+Official docs:
+
+- InstantSearch Android API reference: https://www.algolia.com/doc/api-reference/widgets/android
+- InstantSearch iOS API reference: https://www.algolia.com/doc/api-reference/widgets/ios
+- Algolia for Flutter (Flutter Helper) API reference: https://www.algolia.com/doc/api-reference/widgets/flutter
+- Android install: https://www.algolia.com/doc/guides/building-search-ui/installation/android
+- iOS install: https://www.algolia.com/doc/guides/building-search-ui/installation/ios
+- Flutter install: https://www.algolia.com/doc/guides/building-search-ui/installation/flutter
+- Android events: https://www.algolia.com/doc/guides/building-search-ui/events/android
+- iOS events: https://www.algolia.com/doc/guides/building-search-ui/events/ios
+- Flutter events: https://www.algolia.com/doc/guides/building-search-ui/events/flutter
+
+## Selection Heuristics
+
+- If the user needs search results plus facets, choose InstantSearch for the app framework.
+- If the user needs suggestions while typing, choose Autocomplete and optionally integrate it with InstantSearch.
+- If both are needed, use Autocomplete for entry and InstantSearch for results; define handoff behavior explicitly.
+- If the app is server-rendered, verify SSR and routing docs before implementation.
+- If the app must protect restricted records, review secured API key docs and index filters before exposing UI.
+- If the search UI will drive analytics, personalization, Recommend, NeuralSearch evaluation, or Agent Studio feedback, wire events deliberately.
+
+## QA Checklist
+
+- Query, clear query, and no-query behavior.
+- Filters, facets, sort, pagination or infinite hits.
+- URL routing and browser back/forward when required.
+- Empty, loading, and error states.
+- Mobile filter/sort and autocomplete behavior.
+- Keyboard navigation and accessible labels.
+- Click/conversion events with queryID/objectID/position/userToken.
+- Secured API keys and hidden filters for restricted content.
+- Search request volume and performance.
+- SSR hydration and route restoration when applicable.
+
+## Related Skills
+
+- `$algolia-instantsearch-ui`: full results and browse UI implementation.
+- `$algolia-autocomplete`: typeahead and query suggestion implementation.
+- `$algolia-events-insights`: event attribution and analytics.
+- `$algolia-release-qa`: launch validation.


### PR DESCRIPTION
# feat: add algolia-implementation planning suite (11 skills)

## What

Adds an implementation-planning suite that complements the existing operational skills. Where `algolia-cli`, `algolia-mcp`, `algobot-cli`, and `instantsearch` execute operations and write code, this suite plans, sequences, and validates the work: discovery questions, data/event contracts, relevance decisions, UI readiness, AI-feature rollout, and release QA.

**Skills added** (installed as one `algolia-implementation` plugin):

| Skill | Role |
| --- | --- |
| `algolia-discovery-planning` | Entry point — maps any request to lifecycle phases, loads companions |
| `algolia-search-implementation` | Execution checklist for net-new builds |
| `algolia-data-modeling` | Record shape, variants, objectID, facets, event attribution |
| `algolia-index-configuration` | Relevance settings, synonyms, rules, replicas, rollback |
| `algolia-ui-libraries` | Living selector for current UI libraries |
| `algolia-instantsearch-ui` | Readiness layer for results/browse experiences |
| `algolia-autocomplete` | Source strategy and selection contracts for typeahead |
| `algolia-events-insights` | Event taxonomy, queryID/userToken guidance |
| `algolia-neuralsearch` | NeuralSearch readiness, rollout, measurement |
| `algolia-agent-studio` | Agent Studio planning, guardrails, launch gates |
| `algolia-release-qa` | Severity-led launch QA |

## No overlap with existing skills — by design

Every skill carries explicit `Do NOT use` boundaries routing to the existing skills: live account operations → `algolia-cli` / `algolia-mcp`; Agent Studio config/deploy → `algobot-cli`; framework APIs and code-level UI work → `instantsearch`. The suite is the customer-readiness layer around them, not a replacement. `algolia-discovery-planning` is the single trigger entry point; companions carry precise disambiguation to avoid collisions.

## Quality

- All factual claims audited against current public docs (July 2026): Insights event names and semantics, index settings, NeuralSearch activation behavior, Agent Studio terminology, Angular InstantSearch deprecation.
- Each skill ships `SKILL.md` (<160 lines), `references/`, `agents/openai.yaml`, and `evals/evals.json` (32 evals total).
- `scripts/validate_skills.py`: 122 checks, 0 failures.
- MIT-licensed, no customer data or credentials.

## Provenance

Developed in [itsdanwilli/algolia-implementation-skills](https://github.com/itsdanwilli/algolia-implementation-skills) with SME review. Contact: daniel.williams@algolia.com.
